### PR TITLE
feat: add Shift+Enter support for multiline input

### DIFF
--- a/src/components/TerminalPanel.tsx
+++ b/src/components/TerminalPanel.tsx
@@ -161,7 +161,12 @@ export function TerminalPanel({ terminalId, isActive = true }: TerminalPanelProp
 
     const fitAddon = new FitAddon()
     const unicode11Addon = new Unicode11Addon()
+    const webLinksAddon = new WebLinksAddon((event, uri) => {
+      // Open URL in default browser
+      window.electronAPI.shell.openExternal(uri)
+    })
     terminal.loadAddon(fitAddon)
+    terminal.loadAddon(webLinksAddon)
     terminal.open(containerRef.current)
 
     // Load unicode11 addon after terminal is open


### PR DESCRIPTION
Allow users to insert newlines using Shift+Enter in the terminal, enabling multiline prompt editing.

Also enables clickable URLs in terminal output - clicking a URL will open it in the default browser.

Tested on macOS.