### PR TITLE
fix: resolve 'spawn node ENOENT' when launching from .dmg on macOS

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,6 +1,35 @@
 import { app, BrowserWindow, ipcMain, dialog, shell, Menu, powerMonitor, clipboard, nativeImage } from 'electron'
 import path from 'path'
 import * as fs from 'fs/promises'
+import { execFileSync } from 'child_process'
+
+// Fix PATH for GUI-launched apps on macOS.
+// When launched via .dmg / Applications, macOS gives a minimal PATH that
+// doesn't include Homebrew (/opt/homebrew/bin), NVM, etc.
+// We source the user's login shell to get the real PATH.
+if (process.platform === 'darwin') {
+  try {
+    const shell = process.env.SHELL || '/bin/zsh'
+    // fish stores PATH as a list; use string join to get colon-separated output
+    const isFish = shell.endsWith('/fish') || shell === 'fish'
+    const cmd = isFish ? 'string join : $PATH' : 'echo $PATH'
+    const rawPath = execFileSync(shell, ['-l', '-c', cmd], {
+      timeout: 3000,
+      encoding: 'utf8',
+    }).trim()
+    if (rawPath) {
+      process.env.PATH = rawPath
+    }
+  } catch {
+    // Fallback: prepend the most common node locations
+    const extraPaths = [
+      '/opt/homebrew/bin',
+      '/usr/local/bin',
+      `${process.env.HOME}/.volta/bin`,
+    ].join(':')
+    process.env.PATH = `${extraPaths}:${process.env.PATH || ''}`
+  }
+}
 import { PtyManager } from './pty-manager'
 import { ClaudeAgentManager } from './claude-agent-manager'
 import { checkForUpdates, UpdateCheckResult } from './update-checker'


### PR DESCRIPTION
When launched via GUI (.dmg / Applications), macOS provides a minimal PATH that excludes Homebrew, NVM, Volta, etc. The claude-agent-sdk internally spawns `node` as a child process, which fails with ENOENT.

Fix: at startup, source the user's login shell to get the real PATH. Handles fish shell separately (uses `string join : $PATH` instead of `echo $PATH` since fish PATH is a list). Falls back to prepending common node locations if shell invocation fails.