### PR TITLE
fix(git): avoid trim() stripping first line's leading space in porcelain output

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -481,7 +481,7 @@ function registerProxiedHandlers() {
       const { execSync } = await import('child_process')
       const raw = execSync('git status --porcelain -uall', { cwd, encoding: 'utf-8', timeout: 5000 })
       if (!raw.trim()) return []
-      return raw.trim().split('\n').map(line => ({ status: line.substring(0, 2).trim(), file: line.substring(3) }))
+      return raw.split('\n').filter(line => line.trim()).map(line => ({ status: line.substring(0, 2).trim(), file: line.substring(3) }))
     } catch { return [] }
   })
 


### PR DESCRIPTION
## Problem
`git status --porcelain` output uses the first two characters as status codes, where leading spaces are meaningful (e.g., ` M` indicates unstaged-only changes). The previous implementation used `raw.trim().split('\n')`, which stripped the first line's leading space and caused incorrect status code parsing.

## Root Cause
`raw.trim()` operates on the entire string, removing the leading whitespace from the first line's status code before splitting into individual lines.

## Fix
Replace `raw.trim().split('\n')` with `raw.split('\n').filter(line => line.trim())` — this splits first, then filters out empty lines, preserving each line's original content including leading spaces.