### PR TITLE
fix(ui): replace blocking window.confirm with async Electron dialog

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -567,6 +567,18 @@ function registerLocalHandlers() {
     return result.canceled ? [] : result.filePaths
   })
 
+  ipcMain.handle('dialog:confirm', async (_event, message: string, title?: string) => {
+    const result = await dialog.showMessageBox(mainWindow!, {
+      type: 'warning',
+      buttons: ['OK', 'Cancel'],
+      defaultId: 1,
+      cancelId: 1,
+      title: title || 'Confirm',
+      message,
+    })
+    return result.response === 0
+  })
+
   ipcMain.handle('shell:open-external', async (_event, url: string) => { await shell.openExternal(url) })
   ipcMain.handle('shell:open-path', async (_event, folderPath: string) => { await shell.openPath(folderPath) })
 

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -46,6 +46,7 @@ const electronAPI = {
   dialog: {
     selectFolder: () => ipcRenderer.invoke('dialog:select-folder'),
     selectImages: () => ipcRenderer.invoke('dialog:select-images') as Promise<string[]>,
+    confirm: (message: string, title?: string) => ipcRenderer.invoke('dialog:confirm', message, title) as Promise<boolean>,
   },
   image: {
     readAsDataUrl: (filePath: string) => ipcRenderer.invoke('image:read-as-data-url', filePath) as Promise<string>,

--- a/src/components/ClaudeAgentPanel.tsx
+++ b/src/components/ClaudeAgentPanel.tsx
@@ -767,7 +767,8 @@ export function ClaudeAgentPanel({ sessionId, cwd, isActive, workspaceId }: Read
     const idx = permissionModes.indexOf(permissionMode as typeof permissionModes[number])
     const nextMode = permissionModes[(idx + 1) % permissionModes.length]
     if ((nextMode === 'bypassPermissions' || nextMode === 'planBypass') && !settingsStore.getSettings().allowBypassPermissions) {
-      if (!window.confirm('Warning: This mode allows tool calls without confirmation. Continue?')) {
+      const confirmed = await window.electronAPI.dialog.confirm('Warning: This mode allows tool calls without confirmation. Continue?')
+      if (!confirmed) {
         return
       }
     }


### PR DESCRIPTION
## Problem

`window.confirm()` synchronously blocks the Electron renderer process, causing the textarea to become completely unresponsive after the dialog is dismissed.

## Root Cause

`window.confirm()` is a synchronous browser API that halts the renderer's event loop. In Electron, this leaves the textarea unresponsive even after the dialog closes.

## Fix

Replace `window.confirm()` with async `dialog.showMessageBox()` via IPC — add a `dialog:confirm` handler in main process, expose it through preload, and `await` it in the renderer. This keeps the event loop running while the dialog is open.
