### PR TITLE
feat(usage): support Windows/Linux credential reading for usage polling

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -392,15 +392,26 @@ function registerProxiedHandlers() {
   // Claude usage (5h / 7d rate limits)
   registerHandler('claude:get-usage', async () => {
     try {
-      if (process.platform !== 'darwin') return null
-      const { execSync } = await import('child_process')
-      const username = execSync('whoami', { encoding: 'utf-8' }).trim()
-      const raw = execSync(
-        `security find-generic-password -s "Claude Code-credentials" -a "${username}" -w 2>/dev/null`,
-        { encoding: 'utf-8', timeout: 3000 }
-      ).trim()
-      const creds = JSON.parse(raw)
-      const token = creds?.claudeAiOauth?.accessToken
+      let token: string | null = null
+
+      if (process.platform === 'darwin') {
+        // macOS: read from Keychain
+        const { execSync } = await import('child_process')
+        const username = execSync('whoami', { encoding: 'utf-8' }).trim()
+        const raw = execSync(
+          `security find-generic-password -s "Claude Code-credentials" -a "${username}" -w 2>/dev/null`,
+          { encoding: 'utf-8', timeout: 3000 }
+        ).trim()
+        const creds = JSON.parse(raw)
+        token = creds?.claudeAiOauth?.accessToken ?? null
+      } else {
+        // Windows / Linux: read from ~/.claude/.credentials.json
+        const credPath = path.join(app.getPath('home'), '.claude', '.credentials.json')
+        const raw = await fs.readFile(credPath, 'utf-8')
+        const creds = JSON.parse(raw)
+        token = creds?.claudeAiOauth?.accessToken ?? null
+      }
+
       if (!token || !token.startsWith('sk-ant-oat')) return null
 
       const res = await fetch('https://api.anthropic.com/api/oauth/usage', {


### PR DESCRIPTION
## Problem

The `claude:get-usage` handler only supports macOS (reads OAuth token from Keychain via `security` command). On Windows/Linux, it immediately returns `null`, so the usage percentage (5h/7d) never appears in the status bar.

## Root Cause

A hard-coded `if (process.platform !== 'darwin') return null` guard at the top of the handler blocks all non-macOS platforms from reading credentials.

## Fix

Add a platform-aware credential reading path: macOS continues using Keychain, while Windows/Linux reads the OAuth token from `~/.claude/.credentials.json` (the file-based credential store Claude Code uses on these platforms). Uses `app.getPath('home')` to resolve the home directory.