### PR TITLE
fix: kill zombie processes on Windows when app closes

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -304,16 +304,27 @@ app.whenReady().then(async () => {
   }, 2000)
 })
 
-app.on('before-quit', () => {
+// Cleanup runs once: before-quit covers cmd+Q / File→Quit paths,
+// window-all-closed covers the user closing the last window.
+// Guard with a flag to avoid running twice.
+let _cleanupDone = false
+function runCleanupOnce() {
+  if (_cleanupDone) return
+  _cleanupDone = true
   cleanupAllProcesses()
+}
+
+app.on('before-quit', () => {
+  runCleanupOnce()
 })
 
 app.on('window-all-closed', () => {
-  cleanupAllProcesses()
+  runCleanupOnce()
   if (process.platform !== 'darwin') {
     app.quit()
-    // Force exit after a short delay in case child processes keep the event loop alive
-    setTimeout(() => process.exit(0), 1000)
+    // Force exit — child processes (PTY shells, Claude CLI) may keep the event loop alive.
+    // PTY kill() already called taskkill /T above; this is a final safety net.
+    setTimeout(() => process.exit(0), 2000)
   }
 })
 

--- a/electron/pty-manager.ts
+++ b/electron/pty-manager.ts
@@ -238,10 +238,19 @@ export class PtyManager {
   kill(id: string): boolean {
     const instance = this.instances.get(id)
     if (instance) {
+      const pid: number | undefined = instance.process.pid
       if (instance.usePty) {
         instance.process.kill()
       } else {
         (instance.process as ChildProcess).kill()
+      }
+      // On Windows, kill() only terminates the direct shell process.
+      // Use taskkill /T to forcefully terminate the entire process tree.
+      if (process.platform === 'win32' && pid) {
+        try {
+          const { execFileSync } = require('child_process')
+          execFileSync('taskkill', ['/F', '/T', '/PID', String(pid)], { stdio: 'ignore', timeout: 3000 })
+        } catch { /* process may already be gone */ }
       }
       this.instances.delete(id)
       return true


### PR DESCRIPTION
- PtyManager.kill(): add taskkill /F /T /PID to terminate the full process tree on Windows; .kill() alone only terminates the direct shell, leaving child processes (git, node, user programs) as orphans
- main.ts: guard cleanupAllProcesses() with _cleanupDone flag so it runs exactly once across before-quit and window-all-closed events
- main.ts: extend force-exit timeout to 2s to allow taskkill to complete