### PR TITLE
fix(permissions): remove stale closure that overrides user's permissi…

### DIFF
--- a/src/components/ClaudeAgentPanel.tsx
+++ b/src/components/ClaudeAgentPanel.tsx
@@ -147,7 +147,6 @@ export function ClaudeAgentPanel({ sessionId, cwd, isActive, workspaceId }: Read
   const inputHistoryRef = useRef<string[]>([])
   const inputHistoryIndexRef = useRef(-1)
   const inputDraftRef = useRef('')
-  const initialModeAppliedRef = useRef(false)
   const pendingPromptSentRef = useRef(false)
   const messagesEndRef = useRef<HTMLDivElement>(null)
   const streamingThinkingRef = useRef<HTMLPreElement>(null)
@@ -462,11 +461,8 @@ export function ClaudeAgentPanel({ sessionId, cwd, isActive, workspaceId }: Read
         const m = meta as SessionMeta
         setSessionMeta(m)
         if (m.model) setCurrentModel(prev => prev || m.model!)
-        // On first status, ensure bypass mode is applied
-        if (!initialModeAppliedRef.current) {
-          initialModeAppliedRef.current = true
-          window.electronAPI.claude.setPermissionMode(sessionId, 'bypassPermissions')
-        } else if (m.permissionMode) {
+        // Sync UI with backend's current permission mode
+        if (m.permissionMode) {
           setPermissionMode(m.permissionMode)
         }
         // Persist SDK session ID per-terminal so /resume and auto-resume can find it
@@ -579,7 +575,7 @@ export function ClaudeAgentPanel({ sessionId, cwd, isActive, workspaceId }: Read
         window.electronAPI.claude.resumeSession(sessionId, savedSdkSessionId, cwd, savedModel)
       } else {
         dlog(`${stag} FRESH startSession`)
-        window.electronAPI.claude.startSession(sessionId, { cwd, permissionMode: 'bypassPermissions', model: savedModel })
+        window.electronAPI.claude.startSession(sessionId, { cwd, permissionMode, model: savedModel })
       }
     }
     return () => {


### PR DESCRIPTION
## Problem
   The `initialModeAppliedRef` callback in `onStatus` always captured the mount-time `permissionMode` (`'bypassPermissions'`) due to stale closure. When a user manually cycled the permission mode before the first status message arrived, the callback would override their selection back to `bypassPermissions`.

   ## Root Cause
   The `onStatus` listener was created inside a `useEffect(..., [sessionId])` that only ran once on mount. The closure captured the initial `permissionMode` state value and never saw subsequent updates from `handlePermissionModeCycle`.

   ## Fix
   Remove the redundant `initialModeAppliedRef` override entirely. `startSession` already passes the initial permission mode to the backend, and `onStatus` now only syncs the backend's mode back to the UI without overwriting.