### PR TITLE
fix(git): use git repo root for file path resolution in GitPanel

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -776,6 +776,12 @@ function registerProxiedHandlers() {
       })
     } catch { return [] }
   })
+  registerHandler('git:getRoot', async (cwd: string) => {
+    try {
+      const { execSync } = await import('child_process')
+      return execSync('git rev-parse --show-toplevel', { cwd, encoding: 'utf-8', timeout: 5000 }).trim()
+    } catch { return null }
+  })
   registerHandler('git:status', async (cwd: string) => {
     try {
       const { execSync } = await import('child_process')

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -186,6 +186,7 @@ const electronAPI = {
     getDiff: (cwd: string, commitHash?: string, filePath?: string) => ipcRenderer.invoke('git:diff', cwd, commitHash, filePath) as Promise<string>,
     getDiffFiles: (cwd: string, commitHash?: string) => ipcRenderer.invoke('git:diff-files', cwd, commitHash) as Promise<{ status: string; file: string }[]>,
     getStatus: (cwd: string) => ipcRenderer.invoke('git:status', cwd) as Promise<{ status: string; file: string }[]>,
+    getRoot: (cwd: string) => ipcRenderer.invoke('git:getRoot', cwd) as Promise<string | null>,
   },
   fs: {
     readdir: (dirPath: string) => ipcRenderer.invoke('fs:readdir', dirPath) as Promise<{ name: string; path: string; isDirectory: boolean }[]>,

--- a/electron/remote/protocol.ts
+++ b/electron/remote/protocol.ts
@@ -28,7 +28,7 @@ export const PROXIED_CHANNELS = new Set([
   // Settings
   'settings:save', 'settings:load', 'settings:get-shell-path',
   // Git
-  'git:branch', 'git:log', 'git:diff', 'git:diff-files', 'git:status', 'git:get-github-url',
+  'git:branch', 'git:log', 'git:diff', 'git:diff-files', 'git:status', 'git:get-github-url', 'git:getRoot',
   // FS
   'fs:readdir', 'fs:readFile', 'fs:search',
   // Snippet

--- a/src/components/GitPanel.tsx
+++ b/src/components/GitPanel.tsx
@@ -100,6 +100,7 @@ export function GitPanel({ workspaceFolderPath }: Readonly<GitPanelProps>) {
   const [filesLoading, setFilesLoading] = useState(false)
   const [diffLoading, setDiffLoading] = useState(false)
   const [isGitRepo, setIsGitRepo] = useState(true)
+  const [gitRoot, setGitRoot] = useState<string | null>(null)
 
   const loadData = useCallback(async () => {
     setLoading(true)
@@ -108,12 +109,14 @@ export function GitPanel({ workspaceFolderPath }: Readonly<GitPanelProps>) {
     setSelectedFile(null)
     setDiff('')
     try {
-      const [logResult, statusResult, branch] = await Promise.all([
+      const [logResult, statusResult, branch, root] = await Promise.all([
         window.electronAPI.git.getLog(workspaceFolderPath),
         window.electronAPI.git.getStatus(workspaceFolderPath),
         window.electronAPI.git.getBranch(workspaceFolderPath),
+        window.electronAPI.git.getRoot(workspaceFolderPath),
       ])
       setIsGitRepo(branch !== null)
+      setGitRoot(root)
       setCommits(logResult)
       setStatus(statusResult)
     } catch {
@@ -157,8 +160,9 @@ export function GitPanel({ workspaceFolderPath }: Readonly<GitPanelProps>) {
         // For untracked/new files, git diff returns empty - read file content directly
         const fileEntry = changedFiles.find(f => f.file === filePath)
         if (fileEntry && (fileEntry.status === '??' || fileEntry.status === 'A')) {
+          const base = gitRoot || workspaceFolderPath
           const sep = window.electronAPI.platform === 'win32' ? '\\' : '/'
-          const fullPath = workspaceFolderPath + sep + filePath.replace(/[/\\]/g, sep)
+          const fullPath = base + sep + filePath.replace(/[/\\]/g, sep)
           const result = await window.electronAPI.fs.readFile(fullPath)
           if (result.content) {
             const lines = result.content.split('\n').map(l => '+' + l).join('\n')
@@ -174,17 +178,18 @@ export function GitPanel({ workspaceFolderPath }: Readonly<GitPanelProps>) {
       setDiff('')
     }
     setDiffLoading(false)
-  }, [workspaceFolderPath, selectedCommit, changedFiles])
+  }, [workspaceFolderPath, selectedCommit, changedFiles, gitRoot])
 
   const handleViewFile = useCallback(async () => {
     if (!selectedFile) return
     setViewMode('file')
     if (fileContent !== null) return // already loaded
+    const base = gitRoot || workspaceFolderPath
     const sep = window.electronAPI.platform === 'win32' ? '\\' : '/'
-    const fullPath = workspaceFolderPath + sep + selectedFile.replace(/[/\\]/g, sep)
+    const fullPath = base + sep + selectedFile.replace(/[/\\]/g, sep)
     const result = await window.electronAPI.fs.readFile(fullPath)
     setFileContent(result.content || result.error || 'Unable to read file')
-  }, [selectedFile, fileContent, workspaceFolderPath])
+  }, [selectedFile, fileContent, workspaceFolderPath, gitRoot])
 
   if (loading) {
     return <div className="git-panel-empty">{t('common.loading')}</div>


### PR DESCRIPTION
## Summary
   - `git status --porcelain` returns paths relative to the repo root, but `workspaceFolderPath` may be a subdirectory, causing duplicated path segments when reading files (e.g. `src/modules/src/modules/file.md`)
   - Added `git:getRoot` handler using `git rev-parse --show-toplevel` to resolve the actual repo root
   - GitPanel now uses the repo root as the base path for file reading, falling back to `workspaceFolderPath` if unavailable

   ## Test plan
   - [x] Open a workspace that is a subdirectory of a git repo
   - [x] Check that untracked/new files display content correctly in the Git panel
   - [x] Verify file viewing works for files in nested subdirectories