### PR TITLE
fix(permission): preserve planBypass mode when SDK reports plan on init

### DIFF
--- a/electron/claude-agent-manager.ts
+++ b/electron/claude-agent-manager.ts
@@ -484,10 +484,15 @@ export class ClaudeAgentManager {
           session.metadata.model = initMsg.model
           session.metadata.sdkSessionId = initMsg.session_id
           session.metadata.cwd = initMsg.cwd || session.cwd
-          logger.log(`[claude:status] EMIT sessionId=${sessionId.slice(0, 8)} sdkSessionId=${session.metadata.sdkSessionId?.slice(0, 8)}`)
+          // SDK reports 'plan' for planBypass (since we map planBypass→plan before sending to SDK).
+          // Only override SDK's value when we detect this specific mismatch to avoid masking other bugs.
+          const reportedMode = (initMsg.permissionMode === 'plan' && session.permissionMode === 'planBypass')
+            ? session.permissionMode
+            : (initMsg.permissionMode || 'default')
+          logger.log(`[claude:status] EMIT sessionId=${sessionId.slice(0, 8)} sdkSessionId=${session.metadata.sdkSessionId?.slice(0, 8)} sdkMode=${initMsg.permissionMode} appMode=${session.permissionMode} reported=${reportedMode}`)
           this.send('claude:status', sessionId, {
             ...session.metadata,
-            permissionMode: initMsg.permissionMode || 'default',
+            permissionMode: reportedMode,
           })
 
         }


### PR DESCRIPTION
   ## Summary
   - When `permissionMode` is `planBypass`, the app maps it to `plan` before sending to the SDK (since the SDK doesn't know about `planBypass`)
   - On SDK init, the `claude:status` event forwarded the SDK-reported `plan` back to the frontend, overwriting the UI state and losing the `planBypass`
   distinction
   - Fix: only override the SDK-reported value when we detect this specific mismatch (SDK says `plan` but session tracks `planBypass`), keeping all other
   modes unchanged

   ## Test plan
   - [ ] Start a session with `planBypass` mode
   - [ ] Verify the frontend displays "Plan (auto-approve)" instead of "Plan mode" after init
   - [ ] Verify other permission modes (`default`, `acceptEdits`, `plan`, `bypassPermissions`) are unaffected