### PR TITLE
Fix: resolve node binary path for Dock/Launchpad launches

### DIFF
--- a/electron/claude-agent-manager.ts
+++ b/electron/claude-agent-manager.ts
@@ -6,6 +6,7 @@ import * as pathModule from 'path'
 import type { ClaudeMessage, ClaudeToolCall, ClaudeSessionState } from '../src/types/claude-agent'
 import type { Query, PermissionMode, CanUseTool, SlashCommand } from '@anthropic-ai/claude-agent-sdk'
 import { logger } from './logger'
+import { getNodeExecutable } from './node-resolver'
 
 // App-level permission mode extends SDK's PermissionMode with bypassPlan
 // bypassPlan = plan mode (read-only exploration) + auto-approve all tool permissions
@@ -328,7 +329,8 @@ export class ClaudeAgentManager {
     try {
       const query = await getQuery()
       const claudeCodePath = resolveClaudeCodePath()
-      logger.log(`[Claude] runQuery: cwd=${session.cwd}, resumeId=${resumeId || 'none'}, claudeCodePath=${claudeCodePath || 'none'}`)
+      const nodeExecutable = getNodeExecutable()
+      logger.log(`[Claude] runQuery: cwd=${session.cwd}, resumeId=${resumeId || 'none'}, claudeCodePath=${claudeCodePath || 'none'}, nodeExecutable=${nodeExecutable}`)
       const canUseTool: CanUseTool = async (toolName, input, opts) => {
         // Check if this is an AskUserQuestion tool — always show UI
         if (toolName === 'AskUserQuestion') {
@@ -432,6 +434,7 @@ export class ClaudeAgentManager {
         ...(session.enable1MContext ? { betas: ['context-1m-2025-08-07'] } : {}),
         canUseTool,
         ...(claudeCodePath ? { pathToClaudeCodeExecutable: claudeCodePath } : {}),
+        ...(nodeExecutable !== 'node' ? { executable: nodeExecutable } : {}),
         stderr: (data: string) => {
           logger.error('[Claude Code stderr]', data)
           stderrOutput += data

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -27,8 +27,25 @@ if (process.platform === 'darwin') {
       '/opt/homebrew/bin',
       '/usr/local/bin',
       `${process.env.HOME}/.volta/bin`,
-    ].join(':')
-    process.env.PATH = `${extraPaths}:${process.env.PATH || ''}`
+    ]
+    // Resolve nvm: find the latest installed version's bin directory.
+    // NOTE: This intentionally duplicates the semver sort from node-resolver.ts
+    // because this code runs at the top level before any ES module imports,
+    // and importing node-resolver here would break the PATH fix ordering.
+    try {
+      const nvmDir = `${process.env.HOME}/.nvm/versions/node`
+      const versions = fsSync.readdirSync(nvmDir).filter((v: string) => v.startsWith('v'))
+      if (versions.length > 0) {
+        versions.sort((a: string, b: string) => {
+          const pa = a.replace(/^v/, '').split('.').map(Number)
+          const pb = b.replace(/^v/, '').split('.').map(Number)
+          for (let i = 0; i < 3; i++) { const d = (pa[i]||0) - (pb[i]||0); if (d !== 0) return d; }
+          return 0
+        })
+        extraPaths.push(`${nvmDir}/${versions[versions.length - 1]}/bin`)
+      }
+    } catch { /* nvm not installed */ }
+    process.env.PATH = `${extraPaths.join(':')}:${process.env.PATH || ''}`
   }
 }
 import { PtyManager } from './pty-manager'

--- a/electron/node-resolver.ts
+++ b/electron/node-resolver.ts
@@ -1,0 +1,165 @@
+/**
+ * Resolve the node binary path for Electron apps.
+ *
+ * When launched from Dock/Launchpad, macOS provides a minimal PATH that
+ * doesn't include nvm, Homebrew, or Volta. This module finds the node
+ * binary by checking common installation paths as fallback.
+ *
+ * Uses lazy resolution (not at module load time) to ensure PATH fixes
+ * in main.ts have a chance to run first.
+ */
+
+import * as fs from 'fs'
+import * as path from 'path'
+
+const HOME = process.env.HOME || ''
+
+interface NodeCandidate {
+  type: 'versioned'
+  dir: string
+  binSubpath: string  // path from version dir to node binary
+}
+
+interface DirectCandidate {
+  type: 'direct'
+  path: string
+}
+
+type Candidate = NodeCandidate | DirectCandidate
+
+function getCandidates(): Candidate[] {
+  if (process.platform === 'darwin') {
+    return [
+      { type: 'versioned', dir: path.join(HOME, '.nvm', 'versions', 'node'), binSubpath: 'bin/node' },
+      { type: 'versioned', dir: path.join(HOME, '.fnm', 'node-versions'), binSubpath: 'installation/bin/node' },
+      { type: 'direct', path: '/opt/homebrew/bin/node' },
+      { type: 'direct', path: '/usr/local/bin/node' },
+      { type: 'direct', path: path.join(HOME, '.volta', 'bin', 'node') },
+    ]
+  } else if (process.platform === 'linux') {
+    return [
+      { type: 'versioned', dir: path.join(HOME, '.nvm', 'versions', 'node'), binSubpath: 'bin/node' },
+      { type: 'versioned', dir: path.join(HOME, '.fnm', 'node-versions'), binSubpath: 'installation/bin/node' },
+      { type: 'direct', path: '/usr/local/bin/node' },
+      { type: 'direct', path: '/usr/bin/node' },
+      { type: 'direct', path: path.join(HOME, '.volta', 'bin', 'node') },
+    ]
+  } else {
+    // Windows
+    return [
+      { type: 'versioned', dir: path.join(HOME, 'AppData', 'Roaming', 'nvm'), binSubpath: 'node.exe' },
+      { type: 'direct', path: 'C:\\Program Files\\nodejs\\node.exe' },
+      { type: 'direct', path: path.join(HOME, '.volta', 'bin', 'node.exe') },
+    ]
+  }
+}
+
+/**
+ * Compare two semver-like version strings (e.g., "v20.19.3" vs "v18.0.0").
+ * Returns positive if a > b, negative if a < b, 0 if equal.
+ */
+export function compareVersions(a: string, b: string): number {
+  const parse = (v: string) => v.replace(/^v/, '').split('.').map(Number)
+  const pa = parse(a)
+  const pb = parse(b)
+  for (let i = 0; i < 3; i++) {
+    const diff = (pa[i] || 0) - (pb[i] || 0)
+    if (diff !== 0) return diff
+  }
+  return 0
+}
+
+/**
+ * Find the latest node binary in a versioned directory (e.g., ~/.nvm/versions/node/).
+ * Returns the absolute path to the node binary, or null if not found.
+ */
+export function findLatestInVersionedDir(dir: string, binSubpath: string): string | null {
+  try {
+    const versions = fs.readdirSync(dir).filter(v => v.startsWith('v'))
+    if (versions.length === 0) return null
+    versions.sort(compareVersions)
+    const latest = versions[versions.length - 1]
+    const nodeBin = path.join(dir, latest, binSubpath)
+    if (fs.existsSync(nodeBin)) return nodeBin
+  } catch { /* directory doesn't exist */ }
+  return null
+}
+
+/**
+ * Scan process.env.PATH for a node binary.
+ */
+function findNodeInPath(): string | null {
+  const pathDirs = (process.env.PATH || '').split(path.delimiter)
+  const nodeName = process.platform === 'win32' ? 'node.exe' : 'node'
+  for (const dir of pathDirs) {
+    if (!dir) continue
+    const candidate = path.join(dir, nodeName)
+    try {
+      if (fs.existsSync(candidate) && fs.statSync(candidate).isFile()) {
+        return candidate
+      }
+    } catch { /* skip */ }
+  }
+  return null
+}
+
+/**
+ * Resolve the node binary path.
+ * First checks if node is already accessible via process.env.PATH,
+ * then falls back to common installation locations.
+ */
+export function resolveNodePath(): string {
+  // 1. Check current PATH
+  const fromPath = findNodeInPath()
+  if (fromPath) return fromPath
+
+  // 2. Check common installation locations
+  for (const entry of getCandidates()) {
+    if (entry.type === 'versioned') {
+      const found = findLatestInVersionedDir(entry.dir, entry.binSubpath)
+      if (found) return found
+    } else {
+      if (fs.existsSync(entry.path)) return entry.path
+    }
+  }
+
+  return 'node' // last resort
+}
+
+// Lazy cached resolution
+let cachedPath: string | null = null
+
+/**
+ * Get the resolved node binary path (lazy, cached).
+ * First call triggers resolution; subsequent calls return cached result.
+ */
+export function getNodeExecutable(): string {
+  if (cachedPath === null) {
+    cachedPath = resolveNodePath()
+  }
+  return cachedPath
+}
+
+/**
+ * Get extra bin directories for PATH augmentation (nvm, fnm, etc.).
+ * Returns an array of bin directories that contain node.
+ *
+ * Not used internally — exported for external consumers and testing.
+ */
+export function getExtraNodePaths(): string[] {
+  const extraPaths: string[] = []
+  for (const entry of getCandidates()) {
+    if (entry.type === 'versioned') {
+      const found = findLatestInVersionedDir(entry.dir, entry.binSubpath)
+      if (found) extraPaths.push(path.dirname(found))
+    }
+  }
+  return extraPaths
+}
+
+/**
+ * Reset cached path (for testing only).
+ */
+export function _resetCache(): void {
+  cachedPath = null
+}

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "test:claude-ctrl-o": "node tests/test-claude-ctrl-o.js",
     "diagnose:ctrl-o": "npx electron tests/diagnose-ctrl-o.js",
     "diagnose:ctrl-o:quick": "npx electron tests/diagnose-ctrl-o.js --quick",
-    "diagnose:ctrl-o:verbose": "npx electron tests/diagnose-ctrl-o.js --verbose"
+    "diagnose:ctrl-o:verbose": "npx electron tests/diagnose-ctrl-o.js --verbose",
+    "test:node-resolver": "npx tsx tests/node-resolver.test.ts"
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.62",

--- a/tests/node-resolver.test.ts
+++ b/tests/node-resolver.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Unit tests for electron/node-resolver.ts
+ *
+ * Run: npx tsx tests/node-resolver.test.ts
+ */
+
+import * as assert from 'assert'
+import * as fs from 'fs'
+import * as path from 'path'
+import * as os from 'os'
+
+// Import the functions we want to test
+import {
+  compareVersions,
+  findLatestInVersionedDir,
+  resolveNodePath,
+  getNodeExecutable,
+  getExtraNodePaths,
+  _resetCache,
+} from '../electron/node-resolver'
+
+let passed = 0
+let failed = 0
+
+function test(name: string, fn: () => void) {
+  try {
+    fn()
+    console.log(`  ✅ ${name}`)
+    passed++
+  } catch (e) {
+    console.log(`  ❌ ${name}`)
+    console.log(`     ${(e as Error).message}`)
+    failed++
+  }
+}
+
+// === compareVersions ===
+console.log('\ncompareVersions:')
+
+test('equal versions', () => {
+  assert.strictEqual(compareVersions('v1.0.0', 'v1.0.0'), 0)
+})
+
+test('major version difference', () => {
+  assert.ok(compareVersions('v20.0.0', 'v18.0.0') > 0)
+  assert.ok(compareVersions('v18.0.0', 'v20.0.0') < 0)
+})
+
+test('minor version difference', () => {
+  assert.ok(compareVersions('v20.19.0', 'v20.1.0') > 0)
+  assert.ok(compareVersions('v20.1.0', 'v20.19.0') < 0)
+})
+
+test('patch version difference', () => {
+  assert.ok(compareVersions('v20.19.3', 'v20.19.1') > 0)
+})
+
+test('v9 vs v20 (string sort would fail)', () => {
+  assert.ok(compareVersions('v20.0.0', 'v9.0.0') > 0)
+})
+
+test('without v prefix', () => {
+  assert.ok(compareVersions('20.0.0', '18.0.0') > 0)
+})
+
+test('mixed v prefix', () => {
+  assert.ok(compareVersions('v20.0.0', '18.0.0') > 0)
+})
+
+test('sorting an array of versions', () => {
+  const versions = ['v9.0.0', 'v20.19.3', 'v18.17.0', 'v20.1.0', 'v14.21.3']
+  versions.sort(compareVersions)
+  assert.deepStrictEqual(versions, ['v9.0.0', 'v14.21.3', 'v18.17.0', 'v20.1.0', 'v20.19.3'])
+})
+
+// === findLatestInVersionedDir ===
+console.log('\nfindLatestInVersionedDir:')
+
+test('returns null for non-existent directory', () => {
+  assert.strictEqual(findLatestInVersionedDir('/nonexistent/path', 'bin/node'), null)
+})
+
+test('finds node in nvm directory (if installed)', () => {
+  const nvmDir = path.join(os.homedir(), '.nvm', 'versions', 'node')
+  const result = findLatestInVersionedDir(nvmDir, 'bin/node')
+  if (fs.existsSync(nvmDir)) {
+    assert.ok(result !== null, 'should find node in nvm directory')
+    assert.ok(result!.endsWith('/bin/node'), `should end with /bin/node, got ${result}`)
+    assert.ok(fs.existsSync(result!), `resolved path should exist: ${result}`)
+  } else {
+    assert.strictEqual(result, null, 'should return null when nvm not installed')
+  }
+})
+
+test('returns null for empty directory', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'node-resolver-test-'))
+  try {
+    assert.strictEqual(findLatestInVersionedDir(tmpDir, 'bin/node'), null)
+  } finally {
+    fs.rmdirSync(tmpDir)
+  }
+})
+
+test('picks latest version from multiple', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'node-resolver-test-'))
+  try {
+    // Create fake version directories with node binaries
+    for (const v of ['v14.0.0', 'v20.19.3', 'v18.17.0', 'v9.0.0']) {
+      const binDir = path.join(tmpDir, v, 'bin')
+      fs.mkdirSync(binDir, { recursive: true })
+      fs.writeFileSync(path.join(binDir, 'node'), '')  // fake binary
+    }
+    const result = findLatestInVersionedDir(tmpDir, 'bin/node')
+    assert.ok(result !== null)
+    assert.ok(result!.includes('v20.19.3'), `should pick v20.19.3, got ${result}`)
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true })
+  }
+})
+
+test('ignores non-version directories', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'node-resolver-test-'))
+  try {
+    fs.mkdirSync(path.join(tmpDir, '.cache'), { recursive: true })
+    fs.mkdirSync(path.join(tmpDir, 'something'), { recursive: true })
+    const binDir = path.join(tmpDir, 'v18.0.0', 'bin')
+    fs.mkdirSync(binDir, { recursive: true })
+    fs.writeFileSync(path.join(binDir, 'node'), '')
+    const result = findLatestInVersionedDir(tmpDir, 'bin/node')
+    assert.ok(result !== null)
+    assert.ok(result!.includes('v18.0.0'))
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true })
+  }
+})
+
+// === resolveNodePath ===
+console.log('\nresolveNodePath:')
+
+test('returns a valid path', () => {
+  const result = resolveNodePath()
+  assert.ok(result.length > 0, 'should return non-empty string')
+  if (result !== 'node') {
+    assert.ok(fs.existsSync(result), `resolved path should exist: ${result}`)
+  }
+})
+
+test('resolved path is actually node', () => {
+  const result = resolveNodePath()
+  if (result !== 'node') {
+    assert.ok(
+      result.endsWith('/node') || result.endsWith('\\node.exe'),
+      `should end with node binary name, got ${result}`
+    )
+  }
+})
+
+// === getNodeExecutable (lazy cache) ===
+console.log('\ngetNodeExecutable (lazy cache):')
+
+test('returns same result on multiple calls', () => {
+  _resetCache()
+  const first = getNodeExecutable()
+  const second = getNodeExecutable()
+  assert.strictEqual(first, second, 'should return cached result')
+})
+
+test('reset cache allows re-resolution', () => {
+  const first = getNodeExecutable()
+  _resetCache()
+  const second = getNodeExecutable()
+  // Should resolve to same path (environment hasn't changed)
+  assert.strictEqual(first, second)
+})
+
+// === getExtraNodePaths ===
+console.log('\ngetExtraNodePaths:')
+
+test('returns an array', () => {
+  const result = getExtraNodePaths()
+  assert.ok(Array.isArray(result))
+})
+
+test('all returned paths are directories', () => {
+  const result = getExtraNodePaths()
+  for (const p of result) {
+    assert.ok(fs.existsSync(p), `path should exist: ${p}`)
+    assert.ok(fs.statSync(p).isDirectory(), `should be a directory: ${p}`)
+  }
+})
+
+// === Summary ===
+console.log(`\n${'='.repeat(40)}`)
+console.log(`Results: ${passed} passed, ${failed} failed`)
+if (failed > 0) process.exit(1)


### PR DESCRIPTION
## Problem

When BAT is launched from **Dock or Launchpad** (not terminal), macOS provides a minimal PATH (`/usr/bin:/bin:/usr/sbin:/sbin`) that doesn't include nvm, Homebrew, or Volta node installations.

This causes Agent mode to fail with:
```
Error: Failed to spawn Claude Code process: spawn node ENOENT
```

**Terminal mode works fine** because pty spawns its own shell which loads `.zshrc`. But Agent mode uses the SDK to spawn node directly from Electron's main process, which has the limited PATH.

Launching via `open -a BetterAgentTerminal` from terminal works because it inherits the terminal's full PATH.

## Root Cause

The existing PATH fix in `main.ts` (lines 11-32) attempts to source the user's login shell to get the real PATH. However, when the login shell extraction fails (e.g., due to Powerlevel10k instant prompt or other interactive shell plugins), the fallback only includes `/opt/homebrew/bin`, `/usr/local/bin`, and `~/.volta/bin` — **missing nvm paths**.

Even when the PATH fix succeeds, the SDK spawns `node` as a bare command, which may not resolve correctly in all cases.

## Solution

### New: `electron/node-resolver.ts`

A shared module that resolves the node binary path with lazy caching:

1. Scans `process.env.PATH` for an existing node binary
2. Falls back to versioned directories (nvm `~/.nvm/versions/node/`, fnm `~/.fnm/node-versions/`)
3. Falls back to direct paths (Homebrew, Volta)
4. Uses proper semver comparison (not string sort — `v9` vs `v20`)
5. **Lazy resolution**: first call triggers resolve, subsequent calls return cached result. This ensures `main.ts` PATH fix runs before resolution.
6. **Platform-aware**: separate candidate paths for macOS, Linux, and Windows

### `electron/claude-agent-manager.ts`

Imports `getNodeExecutable()` from `node-resolver` and passes the resolved absolute path to the SDK via the `executable` option.

### `electron/main.ts`

Added nvm path resolution to the fallback PATH fix. When login shell extraction fails, scans `~/.nvm/versions/node/` for installed versions and adds the latest one to PATH. Semver sort is intentionally inlined (not imported from node-resolver) to avoid module load ordering issues — documented with a comment.

### `tests/node-resolver.test.ts`

19 unit tests covering:
- `compareVersions`: semver ordering, edge cases (v9 vs v20, missing prefix)
- `findLatestInVersionedDir`: non-existent dirs, empty dirs, version picking, non-version filtering
- `resolveNodePath`: path validity
- `getNodeExecutable`: lazy cache behavior
- `getExtraNodePaths`: return type and path validity

Run with: `npm run test:node-resolver`

### Files changed

| File | Change |
|------|--------|
| `electron/node-resolver.ts` | New: shared node resolution module (~140 lines) |
| `electron/claude-agent-manager.ts` | Removed inline resolution, imports from node-resolver (+2, -38) |
| `electron/main.ts` | Added nvm to fallback PATH with semver sort (+14, -3) |
| `tests/node-resolver.test.ts` | New: 19 unit tests |
| `package.json` | Added `test:node-resolver` script |

## Testing

- ✅ Unit tests: 19/19 passed
- ✅ macOS Sequoia (Apple Silicon), nvm-managed Node.js v20
- ✅ Dock launch → Agent mode works (previously ENOENT)
- ✅ Terminal launch (`open -a`) → Agent mode still works
- ✅ Terminal mode unaffected
- ✅ `npx vite build` compiles successfully
- ✅ Full `npm run build` (electron-builder) succeeds