### PR TITLE
feat: add workspace color labels for visual identification

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef, useEffect, useLayoutEffect, useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { Workspace } from '../types'
+import { WORKSPACE_COLORS } from '../types'
 import { workspaceStore } from '../stores/workspace-store'
 import { ActivityIndicator } from './ActivityIndicator'
 
@@ -298,6 +299,9 @@ export function Sidebar({
             onDragLeave={handleDragLeave}
             onDrop={(e) => handleDrop(e, workspace.id)}
           >
+            {workspace.color && (
+              <div className="workspace-color-bar" style={{ backgroundColor: workspace.color }} />
+            )}
             <div className="workspace-item-content">
               <div className="drag-handle" title={t('sidebar.dragToReorder')}>
                 <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor">
@@ -420,6 +424,47 @@ export function Sidebar({
             </svg>
             {t('sidebar.setGroup')}
           </div>
+          {(() => {
+            const ws = workspaces.find(w => w.id === contextMenu.workspaceId)
+            return (
+              <div className="context-menu-item context-menu-color-picker">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                  <circle cx="13.5" cy="6.5" r="2.5" />
+                  <circle cx="17.5" cy="10.5" r="2.5" />
+                  <circle cx="8.5" cy="7.5" r="2.5" />
+                  <circle cx="6.5" cy="12" r="2.5" />
+                  <path d="M12 2C6.5 2 2 6.5 2 12s4.5 10 10 10c.9 0 1.5-.7 1.5-1.5 0-.4-.1-.7-.4-1-.3-.3-.4-.6-.4-1 0-.8.7-1.5 1.5-1.5H16c3.3 0 6-2.7 6-6 0-5.5-4.5-9-10-9z" />
+                </svg>
+                {t('sidebar.setColor')}
+                <div className="color-palette">
+                  {WORKSPACE_COLORS.map(c => (
+                    <div
+                      key={c.id}
+                      className={`color-dot ${ws?.color === c.value ? 'active' : ''}`}
+                      style={{ backgroundColor: c.value }}
+                      title={c.label}
+                      onClick={(e) => {
+                        e.stopPropagation()
+                        workspaceStore.setWorkspaceColor(contextMenu.workspaceId, c.value)
+                        setContextMenu(null)
+                      }}
+                    />
+                  ))}
+                  {ws?.color && (
+                    <div
+                      className="color-dot clear"
+                      onClick={(e) => {
+                        e.stopPropagation()
+                        workspaceStore.setWorkspaceColor(contextMenu.workspaceId, undefined)
+                        setContextMenu(null)
+                      }}
+                      title={t('sidebar.clearColor')}
+                    >&#x2715;</div>
+                  )}
+                </div>
+              </div>
+            )
+          })()}
           <div
             className="context-menu-item"
             onClick={() => {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -93,6 +93,8 @@
     "openInExplorer": "Open in Explorer",
     "openOnGithub": "Open on GitHub",
     "setGroup": "Set Group...",
+    "setColor": "Set Color",
+    "clearColor": "Clear color",
     "environmentVariables": "Environment Variables",
     "detachToWindow": "Detach to Window",
     "wakeAgent": "Wake Agent",

--- a/src/locales/zh-TW.json
+++ b/src/locales/zh-TW.json
@@ -93,6 +93,8 @@
     "openInExplorer": "在檔案管理員中開啟",
     "openOnGithub": "在 GitHub 上開啟",
     "setGroup": "設定群組...",
+    "setColor": "設定顏色",
+    "clearColor": "清除顏色",
     "environmentVariables": "環境變數",
     "detachToWindow": "分離至新視窗",
     "wakeAgent": "喚醒 Agent",

--- a/src/stores/workspace-store.ts
+++ b/src/stores/workspace-store.ts
@@ -472,6 +472,17 @@ class WorkspaceStore {
     this.save()
   }
 
+  setWorkspaceColor(id: string, color: string | undefined): void {
+    this.state = {
+      ...this.state,
+      workspaces: this.state.workspaces.map(w =>
+        w.id === id ? { ...w, color } : w
+      )
+    }
+    this.notify()
+    this.save()
+  }
+
   getGroups(): string[] {
     const groups = new Set<string>()
     for (const w of this.state.workspaces) {

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -103,6 +103,60 @@
   color: white;
 }
 
+/* Workspace color bar */
+.workspace-color-bar {
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 4px;
+  border-radius: 4px 0 0 4px;
+}
+
+.workspace-item.active .workspace-color-bar {
+  box-shadow: 0 0 4px rgba(255, 255, 255, 0.5);
+  filter: brightness(1.3);
+}
+
+/* Color picker in context menu */
+.context-menu-color-picker {
+  flex-wrap: wrap;
+  position: relative;
+}
+
+.color-palette {
+  display: flex;
+  gap: 4px;
+  margin-left: auto;
+  align-items: center;
+}
+
+.color-dot {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  cursor: pointer;
+  border: 2px solid transparent;
+  transition: transform 0.1s;
+}
+
+.color-dot:hover {
+  transform: scale(1.2);
+}
+
+.color-dot.active {
+  border-color: white;
+}
+
+.color-dot.clear {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 10px;
+  color: var(--text-secondary);
+  background: var(--bg-hover);
+}
+
 .workspace-item .remove-btn {
   opacity: 0;
   background: none;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -16,8 +16,20 @@ export interface Workspace {
   defaultAgent?: AgentPresetId;  // Workspace 預設 Agent
   envVars?: EnvVariable[];       // Workspace 專屬環境變數
   group?: string;                // Workspace 分組
+  color?: string;                // Workspace 顏色標籤
   lastSdkSessionId?: string;     // 上次使用的 SDK session ID，下次自動 resume
 }
+
+export const WORKSPACE_COLORS = [
+  { id: 'red', value: '#e74c3c', label: 'Red' },
+  { id: 'orange', value: '#e67e22', label: 'Orange' },
+  { id: 'yellow', value: '#f1c40f', label: 'Yellow' },
+  { id: 'green', value: '#2ecc71', label: 'Green' },
+  { id: 'blue', value: '#3498db', label: 'Blue' },
+  { id: 'purple', value: '#9b59b6', label: 'Purple' },
+  { id: 'pink', value: '#e91e8a', label: 'Pink' },
+  { id: 'gray', value: '#95a5a6', label: 'Gray' },
+] as const
 
 export interface TerminalInstance {
   id: string;


### PR DESCRIPTION
## Summary

Add colored left-border indicators to workspaces in the sidebar for quick visual identification and categorization.

## Screenshots

| Before | After |
|--------|-------|
| No color indicators | 4px color bar on left edge of workspace items |

<img width="440" height="720" alt="image" src="https://github.com/user-attachments/assets/0baa3978-6652-4ae3-9818-a800aabdc904" />

**Features:**
- 8-color palette: red, orange, yellow, green, blue, purple, pink, gray
- Set via right-click context menu → "Set Color" with inline color dot picker
- Clear button (✕) to remove color
- Active workspace has brightened color bar with subtle glow for visibility
- Colors persist across sessions (saved with workspace data)

## Changes

| File | Change |
|------|--------|
| `src/types/index.ts` | Added `color?: string` to Workspace, `WORKSPACE_COLORS` palette constant (+12) |
| `src/stores/workspace-store.ts` | Added `setWorkspaceColor()` method (+11) |
| `src/components/Sidebar.tsx` | Color bar rendering + context menu color picker (+45) |
| `src/styles/layout.css` | Color bar styles, color picker styles, active state glow (+54) |
| `src/locales/en.json` | Added "Set Color", "Clear color" (+2) |
| `src/locales/zh-TW.json` | Added "設定顏色", "清除顏色" (+2) |

**Total: 6 files, +126 lines, 0 deletions**

## Design Decisions

- **Left border bar** (not full background) to avoid conflicting with the activity indicator (green/orange dot on the right)
- **Active state brightening** (`filter: brightness(1.3)` + white box-shadow) so the color bar remains visible against the blue active background
- **Inline color dots** in context menu rather than a submenu, for fewer clicks
- **No prop drilling** — calls `workspaceStore.setWorkspaceColor()` directly from the context menu, following the existing pattern
- **Single `find()` call** — workspace lookup done once outside the color map loop

## Testing

- ✅ Set color → color bar appears
- ✅ Switch color → color bar updates
- ✅ Clear color → color bar disappears
- ✅ Active workspace → color bar has glow effect
- ✅ Persistence → color survives app restart
- ✅ No color set → no color bar rendered
- ✅ `npx vite build` compiles successfully
- ✅ Full `npm run build` (electron-builder) succeeds