### PR TITLE
fix: support file:// URLs in LinkedText

### DIFF
--- a/src/components/PathLinker.tsx
+++ b/src/components/PathLinker.tsx
@@ -103,9 +103,9 @@ const PATH_RE = /(?:[A-Za-z]:[\\\/]|\/(?:Users|home|tmp|var|opt|etc|usr|mnt|srv|
 type TokenType = 'text' | 'path' | 'url' | 'mdlink'
 interface Token { type: TokenType; text: string; href?: string }
 
-// Markdown link: [text](url)  |  Bare URL: https://... or http://...
-const MD_LINK_RE = /\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g
-const URL_RE = /https?:\/\/[^\s<>)\]]+/g
+// Markdown link: [text](url)  |  Bare URL: https://..., http://..., or file:///...
+const MD_LINK_RE = /\[([^\]]+)\]\(((?:https?|file):\/\/[^\s)]+)\)/g
+const URL_RE = /(?:https?|file):\/\/[^\s<>)\]]+/g
 
 function tokenize(text: string): Token[] {
   // Pass 1: extract markdown links and bare URLs


### PR DESCRIPTION
## Problem

`file:///` URLs in tool output (e.g., Bash results) are not correctly detected as clickable links. The URL gets partially matched by `PATH_RE` instead of `URL_RE`, causing the link to be broken or misaligned.

Example:
```
Open in browser: file:///tmp/test-report.html
```

<img width="2934" height="592" alt="image" src="https://github.com/user-attachments/assets/9fb4904e-31bf-4545-8e83-90d59d88679f" />


Before: `file:` detected as text, `///tmp/...` partially matched as path → broken link
After: `file:///tmp/test-report.html` correctly detected as a single URL → clickable link

## Root Cause

`URL_RE` and `MD_LINK_RE` in `PathLinker.tsx` only matched `http://` and `https://`:

```javascript
// Before
const URL_RE = /https?:\/\/[^\s<>)\]]+/g
```

`file://` URLs fell through to `PATH_RE` which only matched the path portion, breaking the link.

## Fix

Add `file://` protocol support to both regex patterns:

```javascript
// After
const URL_RE = /(?:https?|file):\/\/[^\s<>)\]]+/g
const MD_LINK_RE = /\[([^\]]+)\]\(((?:https?|file):\/\/[^\s)]+)\)/g
```

## Changes

| File | Change |
|------|--------|
| `src/components/PathLinker.tsx` | Updated `URL_RE` and `MD_LINK_RE` to include `file://` protocol (+3, -3) |

## Testing

- ✅ `file:///tmp/test-report.html` → correctly matched as single clickable URL
- ✅ `https://github.com/...` → still works
- ✅ `http://localhost:3000` → still works
- ✅ Multiple URLs in one line → all correctly matched
- ✅ `npx vite build` compiles successfully