### PR TITLE
feat: collapse output for read-only tools (Read, Glob, Grep, LS)

### DIFF
--- a/src/components/ClaudeAgentPanel.tsx
+++ b/src/components/ClaudeAgentPanel.tsx
@@ -2043,6 +2043,9 @@ export function ClaudeAgentPanel({ sessionId, cwd, isActive, workspaceId }: Read
               {item.result && (() => {
                 const raw = typeof item.result === 'string' ? item.result : String(item.result)
                 const { content: outText, reminders, errors } = splitSystemReminders(raw)
+                // Hide output by default for read-only tools (Read, Glob, Grep, LS, NotebookRead)
+                const isReadOnlyTool = ['Read', 'Glob', 'Grep', 'LS', 'NotebookRead'].includes(item.toolName)
+                const isOutExpanded = expandedTools.has(outBlockId)
                 return (
                   <>
                     {errors.length > 0 && errors.map((err, i) => (
@@ -2051,7 +2054,22 @@ export function ClaudeAgentPanel({ sessionId, cwd, isActive, workspaceId }: Read
                         <span className="claude-tool-row-content">{err}</span>
                       </div>
                     ))}
-                    {outText && (
+                    {outText && isReadOnlyTool && (
+                      <div
+                        className="claude-tool-row"
+                        onClick={() => toggleTool(outBlockId)}
+                      >
+                        <span className="claude-tool-row-label">{t('claude.out')}</span>
+                        <span className="claude-tool-row-content">
+                          {isOutExpanded
+                            ? <LinkedText text={outText} />
+                            : <span className="claude-tool-collapsed-hint">{outText.split('\n').length} lines</span>
+                          }
+                        </span>
+                        <span className={`claude-tool-chevron ${isOutExpanded ? 'expanded' : ''}`}>&#9654;</span>
+                      </div>
+                    )}
+                    {outText && !isReadOnlyTool && (
                       <div
                         className="claude-tool-row"
                         onClick={() => handleCopyBlock(outText, outBlockId)}


### PR DESCRIPTION
## Summary
- Read-only tool results (Read, Glob, Grep, LS, NotebookRead) now collapse output by default, showing only line count
- Click to expand full content
- Reduces visual noise from large file reads in the agent panel

## Test plan
- [ ] Verify Read tool shows collapsed "X lines" instead of full content
- [ ] Click expands content correctly
- [ ] Bash/Skill/other tools still show output immediately (unchanged behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)