### PR TITLE
fix: use retryAfterSec directly for usage rate-limit backoff

### DIFF
--- a/src/stores/workspace-store.ts
+++ b/src/stores/workspace-store.ts
@@ -41,12 +41,11 @@ class WorkspaceStore {
       if (!u) return
 
       // Handle rate-limit response from main process
+      // Use server's retryAfterSec directly — do not double existing interval,
+      // since OAuth always rate-limits on Windows and exponential backoff causes 1.5h+ staleness
       if ('rateLimited' in u && (u as any).rateLimited) {
         const retryAfterMs = ((u as any).retryAfterSec || 60) * 1000
-        this._usageCurrentInterval = Math.min(
-          Math.max(retryAfterMs, this._usageCurrentInterval * 2),
-          this._usageMaxInterval
-        )
+        this._usageCurrentInterval = Math.min(retryAfterMs, this._usageMaxInterval)
         return
       }
 


### PR DESCRIPTION
## Summary
- Fixes 5h usage display going stale for 1.5h+ on Windows
- Root cause: OAuth always rate-limits on Windows (no Chrome session key), causing exponential backoff to accumulate: 2→4→8→16→30→30→30 min = 90min staleness
- Fix: use server's `retryAfterSec` (120s) directly instead of doubling the current interval
- No impact on macOS where Chrome session key path is used primarily

## Test plan
- [ ] On Windows: 5h usage updates within 2min after a rate-limit response
- [ ] On macOS with Chrome session key: behavior unchanged (this code path rarely hit)
- [ ] Network errors still use exponential backoff (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)