### PR TITLE
feat: update 5h/7d usage from SDK rate_limit_event

### DIFF
--- a/electron/claude-agent-manager.ts
+++ b/electron/claude-agent-manager.ts
@@ -588,6 +588,14 @@ export class ClaudeAgentManager {
         }
         if (message.type === 'rate_limit_event') {
           logger.log(`[claude:rate_limit_event] ${JSON.stringify(message)}`)
+          const info = (message as { rate_limit_info?: { rateLimitType?: string; utilization?: number; resetsAt?: number } }).rate_limit_info
+          if (info?.rateLimitType && info.utilization !== undefined) {
+            this.send('claude:usage-update', {
+              rateLimitType: info.rateLimitType,
+              utilization: info.utilization,
+              resetsAt: info.resetsAt,
+            })
+          }
         }
         if (message.type === 'assistant') {
           const blocks = (message as { message?: { content?: unknown[] } }).message?.content

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -115,6 +115,11 @@ const electronAPI = {
       ipcRenderer.on('claude:modeChange', handler)
       return () => ipcRenderer.removeListener('claude:modeChange', handler)
     },
+    onUsageUpdate: (callback: (info: { rateLimitType: string; utilization: number; resetsAt?: number }) => void) => {
+      const handler = (_event: Electron.IpcRendererEvent, info: { rateLimitType: string; utilization: number; resetsAt?: number }) => callback(info)
+      ipcRenderer.on('claude:usage-update', handler)
+      return () => ipcRenderer.removeListener('claude:usage-update', handler)
+    },
     setPermissionMode: (sessionId: string, mode: string) =>
       ipcRenderer.invoke('claude:set-permission-mode', sessionId, mode),
     setModel: (sessionId: string, model: string) =>

--- a/src/components/ClaudeAgentPanel.tsx
+++ b/src/components/ClaudeAgentPanel.tsx
@@ -813,6 +813,13 @@ export function ClaudeAgentPanel({ sessionId, cwd, isActive, workspaceId }: Read
     })
   }, [])
 
+  // Update usage from SDK rate_limit_event (no polling needed, fires on every query)
+  useEffect(() => {
+    return window.electronAPI.claude.onUsageUpdate((info) => {
+      workspaceStore.applyRateLimitEvent(info)
+    })
+  }, [])
+
   // File picker: debounced search
   useEffect(() => {
     if (!showFilePicker) return

--- a/src/stores/workspace-store.ts
+++ b/src/stores/workspace-store.ts
@@ -93,6 +93,18 @@ class WorkspaceStore {
     document.addEventListener('visibilitychange', this._visibilityHandler)
   }
 
+  /** Update usage from SDK rate_limit_event — no API call needed */
+  applyRateLimitEvent(info: { rateLimitType: string; utilization: number; resetsAt?: number }) {
+    const prev = this._claudeUsage ?? { fiveHour: null, sevenDay: null, fiveHourReset: null, sevenDayReset: null }
+    const resetIso = info.resetsAt ? new Date(info.resetsAt).toISOString() : null
+    if (info.rateLimitType === 'five_hour') {
+      this._claudeUsage = { ...prev, fiveHour: info.utilization, fiveHourReset: resetIso }
+    } else if (info.rateLimitType === 'seven_day' || info.rateLimitType === 'seven_day_opus' || info.rateLimitType === 'seven_day_sonnet') {
+      this._claudeUsage = { ...prev, sevenDay: info.utilization, sevenDayReset: resetIso }
+    }
+    this.notify()
+  }
+
   /** Call after agent activity (turn completed, session ended) for a timely refresh */
   refreshUsageNow() {
     if (!this._usagePollingStarted) return


### PR DESCRIPTION
## Summary
- SDK emits `rate_limit_event` messages on every query containing `rateLimitType`, `utilization`, and `resetsAt`
- BAT previously only logged these events; now parses and broadcasts via `claude:usage-update` IPC
- `workspaceStore.applyRateLimitEvent()` merges five_hour / seven_day data immediately — no extra API calls
- Polling retained as fallback when no query is active
- Fully resolves 5h display staleness on Windows where OAuth polling always rate-limits

## Changes
- `claude-agent-manager.ts`: parse rate_limit_event, send `claude:usage-update`
- `preload.ts`: expose `onUsageUpdate` listener
- `workspace-store.ts`: add `applyRateLimitEvent()`
- `ClaudeAgentPanel.tsx`: subscribe to `onUsageUpdate`

## Test plan
- [ ] Run a query → 5h/7d usage updates immediately after response
- [ ] Works on Windows without polling (OAuth rate-limited)
- [ ] Works on macOS alongside existing Chrome session key polling

🤖 Generated with [Claude Code](https://claude.com/claude-code)