### PR TITLE
fix: handle fs.readFile error response in MarkdownPreviewPanel

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "compile": "vite build",
     "start": "electron .",
     "build": "vite build && electron-builder",
+    "build:dir": "vite build && electron-builder --dir",
     "build:release": "node scripts/build-version.js",
     "postinstall": "node -e \"if(process.platform==='darwin'){const p=require('path').join('node_modules/electron/dist/Electron.app/Contents/Info.plist');try{require('child_process').execSync('plutil -replace CFBundleName -string BetterAgentTerminal '+p+' && plutil -replace CFBundleDisplayName -string BetterAgentTerminal '+p)}catch(e){}}\" && echo 'postinstall done'",
     "test:console": "node tests/console-test.js",

--- a/src/components/MarkdownPreviewPanel.tsx
+++ b/src/components/MarkdownPreviewPanel.tsx
@@ -16,9 +16,14 @@ export function MarkdownPreviewPanel({ filePath, onClose }: MarkdownPreviewPanel
   const fileName = filePath.split(/[/\\]/).pop() || filePath
 
   const loadContent = useCallback(() => {
-    window.electronAPI.fs.readFile(filePath).then(text => {
-      setContent(text)
-      setError(null)
+    window.electronAPI.fs.readFile(filePath).then(result => {
+      if (result.error) {
+        setError(result.error)
+        setContent(null)
+      } else {
+        setContent(result.content ?? '')
+        setError(null)
+      }
     }).catch(err => {
       setError(String(err))
       setContent(null)


### PR DESCRIPTION
## Summary

- Fix `MarkdownPreviewPanel` to handle structured `{ content, error }` response from `electronAPI.fs.readFile` instead of assuming a plain string result
- Add `build:dir` npm script to run full Vite + electron-builder build without producing zip/installer artifacts (`--dir` only)

## Test plan

- [ ] Open a valid markdown file — content renders correctly
- [ ] Open an invalid/missing file path — error message is displayed instead of crashing
- [ ] Run `npm run build:dir` — produces `release/win-unpacked` without zip or NSIS installer

🤖 Generated with [Claude Code](https://claude.com/claude-code)