### PR TITLE
feat: 新增訊息類型 filter 切換按鈕

### DIFF
--- a/src/components/ClaudeAgentPanel.tsx
+++ b/src/components/ClaudeAgentPanel.tsx
@@ -85,6 +85,10 @@ interface ClaudeAgentPanelProps {
   cwd: string
   isActive: boolean
   workspaceId?: string
+  showUserMsg?: boolean
+  showAssistantMsg?: boolean
+  showToolMsg?: boolean
+  showThinkingMsg?: boolean
 }
 
 interface AttachedImage {
@@ -97,7 +101,7 @@ type MessageItem = ClaudeMessage | ClaudeToolCall
 // Track sessions that have been started to prevent duplicate calls across StrictMode remounts
 const startedSessions = new Set<string>()
 
-export function ClaudeAgentPanel({ sessionId, cwd, isActive, workspaceId }: Readonly<ClaudeAgentPanelProps>) {
+export function ClaudeAgentPanel({ sessionId, cwd, isActive, workspaceId, showUserMsg = true, showAssistantMsg = true, showToolMsg = true, showThinkingMsg = true }: Readonly<ClaudeAgentPanelProps>) {
   const { t } = useTranslation()
   const [messages, setMessages] = useState<MessageItem[]>([])
   const inputValueRef = useRef('')
@@ -1615,6 +1619,12 @@ export function ClaudeAgentPanel({ sessionId, cwd, isActive, workspaceId }: Read
   }
 
   const renderMessage = (item: MessageItem, index: number) => {
+    if (isToolCall(item) && !showToolMsg) return null
+    if (!isToolCall(item)) {
+      const msg = item as ClaudeMessage
+      if (msg.role === 'user' && !showUserMsg) return null
+      if (msg.role === 'assistant' && !showAssistantMsg) return null
+    }
     if (isToolCall(item)) {
       // TodoWrite: render as a visual checklist
       if (item.toolName === 'TodoWrite') {
@@ -2149,12 +2159,13 @@ export function ClaudeAgentPanel({ sessionId, cwd, isActive, workspaceId }: Read
         </div>
       )
     }
-    // assistant
+    // assistant — if only thinking and thinking is hidden, skip entirely
+    if (!showThinkingMsg && !msg.content) return null
     return (
       <div key={msg.id || index} className="tl-item">
         <div className="tl-dot dot-assistant" />
         <div className="tl-content claude-message-assistant">
-          {msg.thinking && (() => {
+          {msg.thinking && showThinkingMsg && (() => {
             const isExpanded = expandedTools.has(msg.id) || (autoExpandThinking && !expandedTools.has(`${msg.id}-collapsed`))
             return (
               <div className="claude-thinking-block">
@@ -2269,7 +2280,7 @@ export function ClaudeAgentPanel({ sessionId, cwd, isActive, workspaceId }: Read
           ) : null
           return <Fragment key={item.id || `msg-${i}`}>{divider}{renderMessage(item, i)}</Fragment>
         })}
-        {isStreaming && !streamingText && !streamingThinking && (
+        {isStreaming && !streamingText && !streamingThinking && showThinkingMsg && (
           <div className="tl-item">
             <div className="tl-dot dot-thinking" />
             <div className="tl-content claude-thinking">
@@ -2278,7 +2289,7 @@ export function ClaudeAgentPanel({ sessionId, cwd, isActive, workspaceId }: Read
             </div>
           </div>
         )}
-        {streamingThinking && (
+        {streamingThinking && showThinkingMsg && (
           <div className="tl-item">
             <div className="tl-dot dot-thinking" />
             <div className="tl-content claude-thinking-block">

--- a/src/components/MainPanel.tsx
+++ b/src/components/MainPanel.tsx
@@ -26,6 +26,10 @@ export const MainPanel = memo(function MainPanel({ terminal, isActive, onClose, 
   const [isEditing, setIsEditing] = useState(false)
   const [editValue, setEditValue] = useState(terminal.title)
   const [showPromptBox, setShowPromptBox] = useState(false)
+  const [showUserMsg, setShowUserMsg] = useState(true)
+  const [showAssistantMsg, setShowAssistantMsg] = useState(true)
+  const [showToolMsg, setShowToolMsg] = useState(true)
+  const [showThinkingMsg, setShowThinkingMsg] = useState(true)
 
   const handleDoubleClick = () => {
     setEditValue(terminal.title)
@@ -71,6 +75,42 @@ export const MainPanel = memo(function MainPanel({ terminal, isActive, onClose, 
             <span>{terminal.title}</span>
           )}
         </div>
+        {isClaudeCode && (
+          <div className="msg-filter-bar">
+            <button
+              className={`msg-filter-btn${showUserMsg ? ' active' : ''}`}
+              onClick={() => setShowUserMsg(v => !v)}
+              title={showUserMsg ? t('claude.hideUserMessages') : t('claude.showUserMessages')}
+            >
+              <span className="msg-filter-dot" style={{ background: 'var(--accent-color)' }} />
+              You
+            </button>
+            <button
+              className={`msg-filter-btn${showAssistantMsg ? ' active' : ''}`}
+              onClick={() => setShowAssistantMsg(v => !v)}
+              title={showAssistantMsg ? t('claude.hideAssistantMessages') : t('claude.showAssistantMessages')}
+            >
+              <span className="msg-filter-dot" style={{ background: 'var(--text-secondary)' }} />
+              Message
+            </button>
+            <button
+              className={`msg-filter-btn${showToolMsg ? ' active' : ''}`}
+              onClick={() => setShowToolMsg(v => !v)}
+              title={showToolMsg ? t('claude.hideToolMessages') : t('claude.showToolMessages')}
+            >
+              <span className="msg-filter-dot" style={{ background: '#10b981' }} />
+              Tool
+            </button>
+            <button
+              className={`msg-filter-btn${showThinkingMsg ? ' active' : ''}`}
+              onClick={() => setShowThinkingMsg(v => !v)}
+              title={showThinkingMsg ? t('claude.hideThinkingMessages') : t('claude.showThinkingMessages')}
+            >
+              <span className="msg-filter-dot" style={{ background: 'var(--claude-accent)' }} />
+              Thinking
+            </button>
+          </div>
+        )}
         <div className="main-panel-actions">
           <ActivityIndicator
             terminalId={terminal.id}
@@ -109,6 +149,10 @@ export const MainPanel = memo(function MainPanel({ terminal, isActive, onClose, 
               cwd={terminal.cwd}
               isActive={isActive}
               workspaceId={workspaceId}
+              showUserMsg={showUserMsg}
+              showAssistantMsg={showAssistantMsg}
+              showToolMsg={showToolMsg}
+              showThinkingMsg={showThinkingMsg}
             />
           </Suspense>
         ) : (

--- a/src/styles/panels.css
+++ b/src/styles/panels.css
@@ -15,6 +15,45 @@
   border-bottom: 1px solid var(--border-color);
 }
 
+.msg-filter-bar {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.msg-filter-btn {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 7px;
+  border-radius: 10px;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 11px;
+  cursor: pointer;
+  opacity: 0.4;
+  transition: opacity 0.15s, border-color 0.15s;
+  user-select: none;
+}
+
+.msg-filter-btn:hover {
+  opacity: 0.7;
+}
+
+.msg-filter-btn.active {
+  opacity: 1;
+  border-color: var(--border-color);
+  color: var(--text-primary);
+}
+
+.msg-filter-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
 .main-panel-title {
   font-size: 13px;
   font-weight: 500;


### PR DESCRIPTION
## Overview

在 Claude Agent 面板的 header 新增四個訊息類型切換按鈕，讓使用者能快速顯示或隱藏特定類型的訊息，改善長對話時的可讀性，無視掉那些修改的細節，享受只有對話的 vibe coding。

## Screenshot
<img width="1173" height="607" alt="Snipaste_2026-03-27_23-13-50" src="https://github.com/user-attachments/assets/51b8f25c-1137-4173-abd1-4d3093db90e4" />


## Feature Summary

在面板標題列（僅 claude-code 類型顯示）加入四個帶色點的 pill 型切換按鈕：

| 按鈕 | 顏色 | 控制對象 |
|------|------|---------|
| **You** | 藍色 | 使用者輸入訊息 |
| **Message** | 灰色 | Claude 回覆文字 |
| **Tool** | 綠色 | 工具呼叫項目 |
| **Thinking** | 橘色 | 思考推理區塊 |

按鈕預設全部亮起（active）；點擊後變暗，對應類型訊息從 timeline 消失。

## Technical Changes

**Files Modified:** 3 files, +91 / -5

- **`MainPanel.tsx`** — 新增 4 個 filter state，在 header 渲染 `.msg-filter-bar`，透過 props 傳入 ClaudeAgentPanel
- **`ClaudeAgentPanel.tsx`** — 新增 4 個可選 prop，在 `renderMessage` 依 prop 提前 return null；Thinking 關閉時僅含思考內容的 assistant 訊息（含灰點）整個隱藏；串流 thinking 動畫也受控制
- **`panels.css`** — 新增 `.msg-filter-bar`、`.msg-filter-btn`、`.msg-filter-dot` 樣式

## Testing Validation

- 四種類型各別隱藏與恢復確認正常
- Thinking 關閉後不殘留空白灰點
- `npx vite build` 編譯通過，無 TypeScript 錯誤