### PR TITLE
feat: add PDF preview in file browser

### DIFF
--- a/src/components/FileTree.tsx
+++ b/src/components/FileTree.tsx
@@ -31,10 +31,11 @@ function getFileExt(name: string): string {
   return lower.split('.').pop() || ''
 }
 
-function canPreview(name: string): 'text' | 'image' | null {
+function canPreview(name: string): 'text' | 'image' | 'pdf' | null {
   const ext = getFileExt(name)
   if (TEXT_EXTS.has(ext)) return 'text'
   if (IMAGE_EXTS.has(ext)) return 'image'
+  if (ext === 'pdf') return 'pdf'
   return null
 }
 
@@ -275,6 +276,8 @@ function FilePreview({ filePath, fileName, refreshKey }: { filePath: string; fil
         setError('Failed to load image')
         setLoading(false)
       })
+    } else if (type === 'pdf') {
+      setLoading(false)
     } else {
       setError('Preview not available for this file type')
       setLoading(false)
@@ -295,6 +298,18 @@ function FilePreview({ filePath, fileName, refreshKey }: { filePath: string; fil
     return (
       <div className="file-preview-image">
         <img src={imageUrl} alt={fileName} />
+      </div>
+    )
+  }
+
+  if (canPreview(fileName) === 'pdf') {
+    return (
+      <div className="file-preview-pdf">
+        <iframe
+          src={`file://${filePath}`}
+          style={{ width: '100%', height: '100%', border: 'none' }}
+          title={`PDF Preview: ${fileName}`}
+        />
       </div>
     )
   }

--- a/src/styles/file-browser.css
+++ b/src/styles/file-browser.css
@@ -205,6 +205,11 @@
   object-fit: contain;
 }
 
+.file-preview-pdf {
+  width: 100%;
+  height: 100%;
+}
+
 /* Git Panel - 3 column layout */
 .git-panel {
   display: flex;


### PR DESCRIPTION
## Summary

- Add PDF preview to the file browser using Chromium's built-in PDF viewer via iframe
- Zero additional dependencies — leverages `file://` URL in iframe
- Full Chromium PDF viewer features: page thumbnails, page navigation, zoom, download, print, password-protected PDF support

## Changed files

| File | Change |
|------|--------|
| `src/components/FileTree.tsx` | Add `'pdf'` type to `canPreview()`, render iframe for PDF files |
| `src/styles/file-browser.css` | `.file-preview-pdf` full-size container |

## Test plan

- [x] Click PDF file → renders correctly with Chromium PDF viewer
- [x] Multi-page PDF → scrollable, page count correct
- [x] Zoom (+/-), download, print buttons work
- [x] Switch to other file then back to PDF → reloads correctly
- [x] Click .txt/.json → text preview still works
- [x] Click .md → Markdown preview still works
- [x] Click .png/.jpg → image preview still works
- [x] Click unsupported file → shows "Preview not available"
- [x] Large PDF (>10MB) → no UI freeze
- [x] Password-protected PDF → Chromium shows password prompt
- [x] `npx vite build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)