### PR TITLE
feat: usage polling robustness, 5h pacing indicator, 1M model variant selection

### DIFF
--- a/electron/claude-agent-manager.ts
+++ b/electron/claude-agent-manager.ts
@@ -124,7 +124,6 @@ interface SessionInstance {
   pendingAskUser: Map<string, PendingRequest>
   permissionMode: AppPermissionMode
   effort: 'low' | 'medium' | 'high' | 'max'
-  enable1MContext: boolean
   model?: string
   messageQueue: QueuedMessage[]
   currentPrompt?: string  // Track the currently running prompt for abort context
@@ -301,7 +300,6 @@ export class ClaudeAgentManager {
         pendingAskUser: new Map(),
         permissionMode: options.permissionMode || 'default',
         effort: options.effort || 'medium',
-        enable1MContext: false,
         model: options.model,
         messageQueue: [],
         activeTasks: new Map(),
@@ -509,6 +507,7 @@ export class ClaudeAgentManager {
       const currentMode = session.permissionMode
       // Map app-level bypassPlan to SDK's plan mode
       const sdkMode: PermissionMode = currentMode === 'bypassPlan' ? 'plan' : currentMode
+
       const queryOptions: Record<string, unknown> = {
         abortController: session.abortController,
         cwd: session.cwd,
@@ -524,7 +523,6 @@ export class ClaudeAgentManager {
         toolConfig: { askUserQuestion: { previewFormat: 'html' } },
         agentProgressSummaries: true,
         ...(session.model ? { model: session.model } : {}),
-        ...(session.enable1MContext ? { betas: ['context-1m-2025-08-07'] } : {}),
         ...(installedPlugins.length > 0 ? { plugins: installedPlugins } : {}),
         canUseTool,
         ...(claudeCodePath ? { pathToClaudeCodeExecutable: claudeCodePath } : {}),
@@ -571,6 +569,11 @@ export class ClaudeAgentManager {
         }
       }
 
+      // Debug: log query options and 1M context strategy
+      const qModel = (queryOptions as { model?: string }).model
+      const is1M = qModel?.includes('[1m]') || false
+      logger.log(`[claude:query] sessionId=${sessionId.slice(0, 8)} model=${qModel || 'default'} is1M=${is1M} resume=${resumeId?.slice(0, 8) || 'none'}`)
+
       const generator = query({
         prompt: promptArg as Parameters<typeof query>[0]['prompt'],
         options: queryOptions as Parameters<typeof query>[0]['options'],
@@ -589,7 +592,16 @@ export class ClaudeAgentManager {
           logger.log(`[claude:msg] type=${message.type} subtype=${msgSubtype || ''} parent_tool_use_id=${(message as { parent_tool_use_id?: string }).parent_tool_use_id || 'none'}`)
         }
         if (message.type === 'rate_limit_event') {
-          logger.log(`[claude:rate_limit_event] ${JSON.stringify(message)}`)
+          const msg = message as { rate_limit_info?: { rateLimitType?: string; utilization?: number; resetsAt?: number } }
+          const info = msg.rate_limit_info
+          logger.log(`[claude:rate_limit_event] type=${info?.rateLimitType ?? 'MISSING'} util=${info?.utilization ?? 'MISSING'} resetsAt=${info?.resetsAt ?? 'MISSING'} raw=${JSON.stringify(message)}`)
+          if (info?.rateLimitType) {
+            this.send('claude:usage-update', {
+              rateLimitType: info.rateLimitType,
+              utilization: info.utilization,  // may be undefined — frontend handles it
+              resetsAt: info.resetsAt,
+            })
+          }
         }
         if (message.type === 'assistant') {
           const blocks = (message as { message?: { content?: unknown[] } }).message?.content
@@ -606,9 +618,12 @@ export class ClaudeAgentManager {
 
         if (message.type === 'system' && message.subtype === 'init') {
           // Capture and persist the SDK session ID
-          const initMsg = message as { session_id: string; model?: string; cwd?: string; permissionMode?: string }
+          const initMsg = message as { session_id: string; model?: string; cwd?: string; permissionMode?: string; betas?: string[]; apiKeySource?: string }
           session.sdkSessionId = initMsg.session_id
           sdkSessionIds.set(sessionId, initMsg.session_id)
+
+          // Debug: log init response for 1M context validation
+          logger.log(`[claude:init] sessionId=${sessionId.slice(0, 8)} model=${initMsg.model} betas=${initMsg.betas ? JSON.stringify(initMsg.betas) : 'none'} apiKeySource=${initMsg.apiKeySource || 'unknown'}`)
 
           // Extract metadata from init message
           session.metadata.model = initMsg.model
@@ -783,6 +798,11 @@ export class ClaudeAgentManager {
             if (eventUsage.output_tokens && eventUsage.output_tokens > session.metadata.outputTokens) {
               session.metadata.outputTokens = eventUsage.output_tokens
             }
+            // message_start input_tokens = actual context window usage for this turn
+            if (event.type === 'message_start' && contextTokens > 0) {
+              session.metadata.contextTokens = contextTokens
+              logger.log(`[claude:ctx-live] sessionId=${sessionId.slice(0, 8)} contextTokens=${contextTokens} contextWindow=${session.metadata.contextWindow} pct=${session.metadata.contextWindow > 0 ? Math.round((contextTokens / session.metadata.contextWindow) * 100) : '?'}%`)
+            }
             this.send('claude:status', sessionId, { ...session.metadata })
           }
           if (event.type === 'content_block_delta') {
@@ -954,6 +974,8 @@ export class ClaudeAgentManager {
             logger.log(summary)
             session.metadata.inputTokens = totalInput
             session.metadata.outputTokens = totalOutput
+            // Debug: 1M context validation
+            logger.log(`[claude:1M-check] sessionId=${sessionId.slice(0, 8)} model=${session.model || 'default'} contextWindow=${session.metadata.contextWindow} is1M=${(session.metadata.contextWindow || 0) >= 1000000}`)
           } else if (resultMsg.usage) {
             const usageFull = resultMsg.usage as { input_tokens?: number; output_tokens?: number; cache_creation_input_tokens?: number; cache_read_input_tokens?: number }
             const cacheRead = usageFull.cache_read_input_tokens || 0
@@ -963,11 +985,6 @@ export class ClaudeAgentManager {
             logger.log(line)
             session.metadata.inputTokens = totalInput
             session.metadata.outputTokens = usageFull.output_tokens || 0
-          }
-
-          // Per-turn usage.input_tokens reflects actual current context size
-          if (resultMsg.usage?.input_tokens) {
-            session.metadata.contextTokens = resultMsg.usage.input_tokens
           }
 
           this.send('claude:status', sessionId, { ...session.metadata })
@@ -1196,13 +1213,6 @@ export class ClaudeAgentManager {
     const session = this.sessions.get(sessionId)
     if (!session) return false
     session.effort = effort
-    return true
-  }
-
-  set1MContext(sessionId: string, enable: boolean): boolean {
-    const session = this.sessions.get(sessionId)
-    if (!session) return false
-    session.enable1MContext = enable
     return true
   }
 
@@ -1580,7 +1590,6 @@ export class ClaudeAgentManager {
     const cwd = session.cwd
     const permissionMode = session.permissionMode
     const effort = session.effort
-    const enable1MContext = session.enable1MContext
     const model = session.model
 
     // Tear down old session completely
@@ -1591,15 +1600,7 @@ export class ClaudeAgentManager {
     sdkSessionIds.delete(sessionId)
 
     // Start a fresh session preserving settings
-    const ok = await this.startSession(sessionId, { cwd, permissionMode })
-    if (ok) {
-      const newSession = this.sessions.get(sessionId)
-      if (newSession) {
-        newSession.effort = effort
-        newSession.enable1MContext = enable1MContext
-        newSession.model = model
-      }
-    }
+    const ok = await this.startSession(sessionId, { cwd, permissionMode, effort, model })
     // Notify all windows to clear UI for this session
     this.send('claude:session-reset', sessionId)
     return ok

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -115,14 +115,17 @@ const electronAPI = {
       ipcRenderer.on('claude:modeChange', handler)
       return () => ipcRenderer.removeListener('claude:modeChange', handler)
     },
+    onUsageUpdate: (callback: (info: { rateLimitType: string; utilization?: number; resetsAt?: number }) => void) => {
+      const handler = (_event: Electron.IpcRendererEvent, info: { rateLimitType: string; utilization?: number; resetsAt?: number }) => callback(info)
+      ipcRenderer.on('claude:usage-update', handler)
+      return () => ipcRenderer.removeListener('claude:usage-update', handler)
+    },
     setPermissionMode: (sessionId: string, mode: string) =>
       ipcRenderer.invoke('claude:set-permission-mode', sessionId, mode),
     setModel: (sessionId: string, model: string) =>
       ipcRenderer.invoke('claude:set-model', sessionId, model),
     setEffort: (sessionId: string, effort: string) =>
       ipcRenderer.invoke('claude:set-effort', sessionId, effort),
-    set1MContext: (sessionId: string, enable: boolean) =>
-      ipcRenderer.invoke('claude:set-1m-context', sessionId, enable),
     resetSession: (sessionId: string) =>
       ipcRenderer.invoke('claude:reset-session', sessionId),
     getSupportedModels: (sessionId: string) =>

--- a/electron/remote/protocol.ts
+++ b/electron/remote/protocol.ts
@@ -16,7 +16,7 @@ export const PROXIED_CHANNELS = new Set([
   'pty:create', 'pty:write', 'pty:resize', 'pty:kill', 'pty:restart', 'pty:get-cwd',
   // Claude
   'claude:start-session', 'claude:send-message', 'claude:stop-session',
-  'claude:set-permission-mode', 'claude:set-model', 'claude:set-effort', 'claude:set-1m-context', 'claude:reset-session',
+  'claude:set-permission-mode', 'claude:set-model', 'claude:set-effort', 'claude:reset-session',
   'claude:get-supported-models', 'claude:get-account-info', 'claude:get-supported-commands', 'claude:get-session-meta',
   'claude:resolve-permission', 'claude:resolve-ask-user',
   'claude:list-sessions', 'claude:resume-session', 'claude:fork-session', 'claude:stop-task', 'claude:rest-session',

--- a/src/components/ClaudeAgentPanel.tsx
+++ b/src/components/ClaudeAgentPanel.tsx
@@ -129,7 +129,6 @@ export function ClaudeAgentPanel({ sessionId, cwd, isActive, workspaceId }: Read
   const [permissionMode, setPermissionMode] = useState<string>('bypassPermissions')
   const [currentModel, setCurrentModel] = useState<string>('')
   const [effortLevel, setEffortLevel] = useState<string>('medium')
-  const [enable1MContext, setEnable1MContext] = useState(false)
   const [claudeUsage, setClaudeUsage] = useState(workspaceStore.claudeUsage)
   const [availableModels, setAvailableModels] = useState<ModelInfo[]>([])
   const [pendingPermission, setPendingPermission] = useState<PendingPermission | null>(null)
@@ -749,7 +748,7 @@ export function ClaudeAgentPanel({ sessionId, cwd, isActive, workspaceId }: Read
         historyLoadedRef.current = true
         window.electronAPI.claude.resumeSession(sessionId, savedSdkSessionId, cwd, savedModel)
       } else {
-        dlog(`${stag} FRESH startSession`)
+        dlog(`${stag} FRESH startSession model=${effectiveModel || 'SDK-default'}`)
         window.electronAPI.claude.startSession(sessionId, { cwd, permissionMode, model: effectiveModel, effort: effectiveEffort as 'low' | 'medium' | 'high' | 'max' })
       }
     }
@@ -776,7 +775,18 @@ export function ClaudeAgentPanel({ sessionId, cwd, isActive, workspaceId }: Read
       window.electronAPI.claude.getSupportedModels(sessionId).then((models: ModelInfo[]) => {
         console.log('[getSupportedModels] raw response:', JSON.stringify(models, null, 2))
         if (models && models.length > 0) {
-          setAvailableModels(models)
+          // Inject [1m] variants for models that support 1M context
+          const withExtras = [...models]
+          const opusEntry = models.find(m => m.value === 'claude-opus-4-6')
+          if (opusEntry && !models.some(m => m.value === 'claude-opus-4-6[1m]')) {
+            const idx = models.indexOf(opusEntry)
+            withExtras.splice(idx + 1, 0, {
+              value: 'claude-opus-4-6[1m]',
+              displayName: 'Claude Opus 4.6 [1M]',
+              description: 'Opus 4.6 with 1M token context window',
+            })
+          }
+          setAvailableModels(withExtras)
         }
       }).catch(() => {})
       window.electronAPI.claude.getAccountInfo(sessionId).then(info => {
@@ -811,6 +821,14 @@ export function ClaudeAgentPanel({ sessionId, cwd, isActive, workspaceId }: Read
     return workspaceStore.subscribe(() => {
       const u = workspaceStore.claudeUsage
       if (u) setClaudeUsage(u)
+    })
+  }, [])
+
+  // Update usage from SDK rate_limit_event (no polling needed, fires on every query)
+  useEffect(() => {
+    return window.electronAPI.claude.onUsageUpdate((info) => {
+      window.electronAPI.debug.log(`[usage:rate_limit_event] type=${info.rateLimitType} util=${info.utilization} resetsAt=${info.resetsAt ?? 'none'}`)
+      workspaceStore.applyRateLimitEvent(info)
     })
   }, [])
 
@@ -1161,6 +1179,11 @@ export function ClaudeAgentPanel({ sessionId, cwd, isActive, workspaceId }: Read
     if (e.key === 'ArrowUp' && !e.shiftKey && !e.nativeEvent.isComposing) {
       const history = inputHistoryRef.current
       if (history.length === 0) return
+      // In multi-line input, only navigate history when cursor is on the first line
+      const ta = e.currentTarget as HTMLTextAreaElement
+      const firstNewline = ta.value.indexOf('\n')
+      const isOnFirstLine = firstNewline === -1 || ta.selectionStart <= firstNewline
+      if (!isOnFirstLine) return
       e.preventDefault()
       if (inputHistoryIndexRef.current === -1) {
         inputDraftRef.current = inputValueRef.current
@@ -1173,6 +1196,11 @@ export function ClaudeAgentPanel({ sessionId, cwd, isActive, workspaceId }: Read
     }
     if (e.key === 'ArrowDown' && !e.shiftKey && !e.nativeEvent.isComposing) {
       if (inputHistoryIndexRef.current === -1) return
+      // In multi-line input, only navigate history when cursor is on the last line
+      const ta = e.currentTarget as HTMLTextAreaElement
+      const lastNewline = ta.value.lastIndexOf('\n')
+      const isOnLastLine = lastNewline === -1 || ta.selectionStart > lastNewline
+      if (!isOnLastLine) return
       e.preventDefault()
       const history = inputHistoryRef.current
       if (inputHistoryIndexRef.current < history.length - 1) {
@@ -1204,13 +1232,6 @@ export function ClaudeAgentPanel({ sessionId, cwd, isActive, workspaceId }: Read
     setEffortLevel(next)
     await window.electronAPI.claude.setEffort(sessionId, next)
   }, [sessionId])
-
-  const handle1MContextToggle = useCallback(async () => {
-    const next = !enable1MContext
-    setEnable1MContext(next)
-    settingsStore.setEnable1MContext(next)
-    await window.electronAPI.claude.set1MContext(sessionId, next)
-  }, [sessionId, enable1MContext])
 
   const showDontAskAgain = (pendingPermission?.suggestions?.length ?? 0) > 0
     || pendingPermission?.toolName === 'ExitPlanMode'
@@ -2061,8 +2082,7 @@ export function ClaudeAgentPanel({ sessionId, cwd, isActive, workspaceId }: Read
               {item.result && (() => {
                 const raw = typeof item.result === 'string' ? item.result : String(item.result)
                 const { content: outText, reminders, errors } = splitSystemReminders(raw)
-                // Hide output by default for read-only tools (Read, Glob, Grep, LS, NotebookRead)
-                const isReadOnlyTool = ['Read', 'Glob', 'Grep', 'LS', 'NotebookRead'].includes(item.toolName)
+                // All tool outputs collapsed by default — click to expand
                 const isOutExpanded = expandedTools.has(outBlockId)
                 return (
                   <>
@@ -2072,7 +2092,7 @@ export function ClaudeAgentPanel({ sessionId, cwd, isActive, workspaceId }: Read
                         <span className="claude-tool-row-content">{err}</span>
                       </div>
                     ))}
-                    {outText && isReadOnlyTool && (
+                    {outText && (
                       <div
                         className="claude-tool-row"
                         onClick={() => toggleTool(outBlockId)}
@@ -2084,20 +2104,15 @@ export function ClaudeAgentPanel({ sessionId, cwd, isActive, workspaceId }: Read
                             : <span className="claude-tool-collapsed-hint">{outText.split('\n').length} lines</span>
                           }
                         </span>
+                        {isOutExpanded && (
+                          <span
+                            className={`claude-tool-row-copy ${copiedId === outBlockId ? 'copied' : ''}`}
+                            onClick={(e) => { e.stopPropagation(); handleCopyBlock(outText, outBlockId) }}
+                          >
+                            {copiedId === outBlockId ? '✓' : '⧉'}
+                          </span>
+                        )}
                         <span className={`claude-tool-chevron ${isOutExpanded ? 'expanded' : ''}`}>&#9654;</span>
-                      </div>
-                    )}
-                    {outText && !isReadOnlyTool && (
-                      <div
-                        className="claude-tool-row"
-                        onClick={() => handleCopyBlock(outText, outBlockId)}
-                        title={t('claude.clickToCopy')}
-                      >
-                        <span className="claude-tool-row-label">{t('claude.out')}</span>
-                        <span className="claude-tool-row-content"><LinkedText text={outText} /></span>
-                        <span className={`claude-tool-row-copy ${copiedId === outBlockId ? 'copied' : ''}`}>
-                          {copiedId === outBlockId ? '✓' : '⧉'}
-                        </span>
                       </div>
                     )}
                     {reminders.length > 0 && (
@@ -2905,9 +2920,11 @@ export function ClaudeAgentPanel({ sessionId, cwd, isActive, workspaceId }: Read
             if (!sessionMeta || sessionMeta.contextWindow <= 0) return null
             const ctxTokens = sessionMeta.contextTokens || (sessionMeta.inputTokens + sessionMeta.outputTokens)
             const pct = Math.round((ctxTokens / sessionMeta.contextWindow) * 100)
+            const ctxColor = pct <= 50 ? '#98c379' : pct < 80 ? '#e5c07b' : '#e06c75'
+            const is1M = sessionMeta.contextWindow >= 1000000
             return (
-              <span key="contextPct" className="claude-statusline-item" title={`context: ${ctxTokens.toLocaleString()} / ${sessionMeta.contextWindow.toLocaleString()} tokens\ntotal: ${(sessionMeta.inputTokens + sessionMeta.outputTokens).toLocaleString()} tok`}>
-                ctx {pct}%
+              <span key="contextPct" className="claude-statusline-item" style={{ color: ctxColor }} title={`context: ${ctxTokens.toLocaleString()} / ${sessionMeta.contextWindow.toLocaleString()} tokens\ntotal: ${(sessionMeta.inputTokens + sessionMeta.outputTokens).toLocaleString()} tok`}>
+                ctx {pct}%{is1M && <span style={{ color: '#6cf', marginLeft: 3, fontWeight: 600 }}>1M</span>}
               </span>
             )
           },
@@ -2918,11 +2935,31 @@ export function ClaudeAgentPanel({ sessionId, cwd, isActive, workspaceId }: Read
             const ws = workspaceId ? workspaceStore.getState().workspaces.find(w => w.id === workspaceId) : null
             return ws ? <span key="workspace" className="claude-statusline-item">{ws.alias || ws.name}</span> : null
           },
-          usage5h: () => claudeUsage?.fiveHour == null ? null : (
-            <span key="usage5h" className={`claude-statusline-item${claudeUsage.fiveHour > 80 ? ' claude-usage-high' : claudeUsage.fiveHour > 50 ? ' claude-usage-mid' : ''}`}>
-              5h:{Math.round(claudeUsage.fiveHour)}%
-            </span>
-          ),
+          usage5h: () => {
+            if (!claudeUsage) return null
+            if (claudeUsage.fiveHourStale) return (
+              <span key="usage5h" className="claude-statusline-item claude-usage-stale">5h:--%</span>
+            )
+            if (claudeUsage.fiveHour == null) return null
+            const pacing = workspaceStore.getUsagePacing()
+            const paceIcon = pacing ? (pacing.onPace ? '▼' : '▲') : ''
+            const paceClass = pacing && !pacing.onPace ? ' claude-usage-overpace' : ''
+            let title = `5h utilization: ${claudeUsage.fiveHour.toFixed(1)}%`
+            if (pacing) {
+              title += `\nTime elapsed: ${pacing.timeElapsedPct.toFixed(0)}%`
+              title += pacing.onPace ? '\nOn pace ── usage within window budget' : '\nOver pace ── burning faster than replenish'
+              if (pacing.estimatedMinutesToLimit != null) {
+                const h = Math.floor(pacing.estimatedMinutesToLimit / 60)
+                const m = pacing.estimatedMinutesToLimit % 60
+                title += `\nEstimated limit in: ${h > 0 ? `${h}h${m}m` : `${m}m`}`
+              }
+            }
+            return (
+              <span key="usage5h" title={title} className={`claude-statusline-item${claudeUsage.fiveHour > 80 ? ' claude-usage-high' : claudeUsage.fiveHour > 50 ? ' claude-usage-mid' : ' claude-usage-low'}${paceClass}`}>
+                5h:{Math.round(claudeUsage.fiveHour)}%{paceIcon}
+              </span>
+            )
+          },
           usage5hReset: () => {
             if (!claudeUsage?.fiveHourReset) return null
             return <span key="usage5hReset" className="claude-statusline-item">↻{fmtRemaining(new Date(claudeUsage.fiveHourReset))}</span>
@@ -2953,8 +2990,8 @@ export function ClaudeAgentPanel({ sessionId, cwd, isActive, workspaceId }: Read
           for (const item of items) {
             let node = renderers[item.id]?.()
             if (!node) continue
-            // Apply color directly on the element via cloneElement to override class-based colors
-            if (item.color && isValidElement(node)) {
+            // Apply color from config, but don't override dynamic colors already set on the element
+            if (item.color && isValidElement(node) && !node.props.style?.color) {
               node = cloneElement(node, { style: { ...(node.props.style || {}), color: item.color } })
             }
             nodes.push(node)

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -312,18 +312,6 @@ export function SettingsPanel({ onClose }: SettingsPanelProps) {
               <p className="settings-hint">{t('settings.allowBypassPermissionsHint')}</p>
             </div>
 
-            <div className="settings-group checkbox-group">
-              <label>
-                <input
-                  type="checkbox"
-                  checked={settings.enable1MContext !== false}
-                  onChange={e => settingsStore.setEnable1MContext(e.target.checked)}
-                />
-                {t('settings.enable1MContext')}
-              </label>
-              <p className="settings-hint">{t('settings.enable1MContextHint')}</p>
-            </div>
-
             <div className="settings-group">
               <label>{t('settings.defaultModel')}</label>
               <input

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -37,8 +37,6 @@
     "autoRunAgentCommandHint": "Automatically execute the agent command (e.g., `claude`) when creating an Agent Terminal.",
     "allowBypassPermissions": "Allow bypass permissions without confirmation",
     "allowBypassPermissionsHint": "When enabled, switching to bypassPermissions mode in Claude Agent Panel will not show a confirmation dialog. Use with caution.",
-    "enable1MContext": "Enable 1M token context window",
-    "enable1MContextHint": "Use the extended 1M token context window for supported models (Opus 4.6, Sonnet 4.6). Disable to use the default 200K context.",
     "defaultModel": "Default Model",
     "defaultModelPlaceholder": "e.g., claude-sonnet-4-5-20250514",
     "defaultModelHint": "Model ID used for new Agent sessions. Leave empty to use SDK default.",

--- a/src/locales/zh-TW.json
+++ b/src/locales/zh-TW.json
@@ -37,8 +37,6 @@
     "autoRunAgentCommandHint": "建立 Agent 終端時自動執行 Agent 指令（例如 `claude`）。",
     "allowBypassPermissions": "允許跳過權限確認",
     "allowBypassPermissionsHint": "啟用後，在 Claude Agent 面板中切換至 bypassPermissions 模式時不會顯示確認對話框。請謹慎使用。",
-    "enable1MContext": "啟用 1M token 上下文視窗",
-    "enable1MContextHint": "對支援的模型（Opus 4.6、Sonnet 4.6）使用擴展的 1M token 上下文視窗。停用則使用預設的 200K 上下文。",
     "defaultModel": "預設模型",
     "defaultModelPlaceholder": "例如 claude-sonnet-4-5-20250514",
     "defaultModelHint": "新 Agent 對話使用的模型 ID。留空則使用 SDK 預設。",

--- a/src/stores/settings-store.ts
+++ b/src/stores/settings-store.ts
@@ -26,7 +26,6 @@ const defaultSettings: AppSettings = {
   defaultTerminalCount: 1,
   createDefaultAgentTerminal: true,
   allowBypassPermissions: true,
-  enable1MContext: true
 }
 
 class SettingsStore {
@@ -182,12 +181,6 @@ class SettingsStore {
 
   setAllowBypassPermissions(allow: boolean): void {
     this.settings = { ...this.settings, allowBypassPermissions: allow }
-    this.notify()
-    this.save()
-  }
-
-  setEnable1MContext(enable: boolean): void {
-    this.settings = { ...this.settings, enable1MContext: enable }
     this.notify()
     this.save()
   }

--- a/src/stores/workspace-store.ts
+++ b/src/stores/workspace-store.ts
@@ -19,49 +19,183 @@ class WorkspaceStore {
   private listeners: Set<Listener> = new Set()
 
   // Global Claude usage (shared across all panels)
-  // Adaptive polling: backs off on rate limits, pauses when hidden, refreshes on focus
-  private _claudeUsage: { fiveHour: number | null; sevenDay: number | null; fiveHourReset: string | null; sevenDayReset: string | null } | null = null
+  // Primary source: SDK rate_limit_event (fires on every query, persisted to localStorage)
+  // Fallback: adaptive polling (cold-start / no session history), backs off on rate limits
+  private _claudeUsage: { fiveHour: number | null; sevenDay: number | null; fiveHourReset: string | null; sevenDayReset: string | null; fiveHourStale?: boolean; sevenDayStale?: boolean /* unused — 7d changes slowly, always show last known value */ } | null = null
   private _usageTimer: ReturnType<typeof setTimeout> | null = null
   private _usagePollingStarted = false
   private _usageInflight = false
-  private _usageBaseInterval = 120 * 1000            // 2 min normal (API has strict rate limits)
-  private _usageCurrentInterval = 120 * 1000
-  private _usageMaxInterval = 30 * 60 * 1000       // 30 min max backoff
-  private _usageMinInterval = 60 * 1000             // 1 min min (after activity)
-  private _usageRateLimitMin = 120 * 1000           // 2 min min when rate limited
+  private _usageRateLimited = false                  // true while in rate-limit backoff — blocks refreshUsageNow
+  private _usageRateLimitStreak = 0                 // consecutive 429s — drives cumulative backoff
+  private _usageBaseInterval = 10 * 60 * 1000       // 10 min idle (SDK events are primary source)
+  private _usageCurrentInterval = 10 * 60 * 1000
+  private _usageMaxInterval = 10 * 60 * 1000        // 10 min max backoff
+  private _usageMinInterval = 60 * 1000              // 1 min min (after activity)
   private _visibilityHandler: (() => void) | null = null
+  // One-shot timer: starts on first failure, cancelled on success, fires once to mark stale
+  private _fiveHourStaleTimer: ReturnType<typeof setTimeout> | null = null
+  private static readonly _FIVE_HOUR_STALE_MS = 10 * 60 * 1000  // 10 min without data → show --%
+  private static readonly _USAGE_CACHE_KEY = 'bat_claude_usage_cache'
 
   get claudeUsage() { return this._claudeUsage }
+
+  /** Pacing analysis for 5h window: compare utilization vs time elapsed percentage.
+   *  Returns null if data is insufficient. */
+  getUsagePacing(): { onPace: boolean; timeElapsedPct: number; estimatedMinutesToLimit: number | null } | null {
+    const u = this._claudeUsage
+    if (!u || u.fiveHour == null || !u.fiveHourReset) return null
+
+    const now = Date.now()
+    const resetMs = new Date(u.fiveHourReset).getTime()
+    const periodMs = 5 * 3600_000
+    const remainingMs = Math.max(0, resetMs - now)
+    const elapsedMs = periodMs - remainingMs
+    if (elapsedMs <= 0) return null
+
+    const timeElapsedPct = (elapsedMs / periodMs) * 100
+    const onPace = u.fiveHour <= timeElapsedPct
+
+    // Predict time to 100% based on current burn rate, capped to remaining window
+    let estimatedMinutesToLimit: number | null = null
+    if (u.fiveHour > 0) {
+      const ratePerMs = u.fiveHour / elapsedMs
+      const remaining = 100 - u.fiveHour
+      if (ratePerMs > 0) {
+        const remainingMin = Math.round(remainingMs / 60_000)
+        estimatedMinutesToLimit = Math.min(Math.round(remaining / ratePerMs / 60_000), remainingMin)
+      }
+    }
+
+    return { onPace, timeElapsedPct, estimatedMinutesToLimit }
+  }
+
+  /** Persist current usage to localStorage so it survives app restarts */
+  private _persistUsage() {
+    if (!this._claudeUsage) return
+    try {
+      const { fiveHourStale: _, ...data } = this._claudeUsage
+      localStorage.setItem(WorkspaceStore._USAGE_CACHE_KEY, JSON.stringify({
+        ...data,
+        savedAt: new Date().toISOString(),
+      }))
+    } catch { /* quota exceeded or unavailable — non-fatal */ }
+  }
+
+  /** Restore persisted usage on startup; clears components whose resetsAt has already passed */
+  private _loadPersistedUsage() {
+    try {
+      const raw = localStorage.getItem(WorkspaceStore._USAGE_CACHE_KEY)
+      if (!raw) return
+      const cached = JSON.parse(raw) as {
+        fiveHour: number | null; sevenDay: number | null
+        fiveHourReset: string | null; sevenDayReset: string | null
+        savedAt?: string
+      }
+      const now = Date.now()
+      const fiveResetMs = cached.fiveHourReset ? new Date(cached.fiveHourReset).getTime() : null
+      const sevenResetMs = cached.sevenDayReset ? new Date(cached.sevenDayReset).getTime() : null
+      // If the reset time has already passed, the limit has rolled over — clear that slot
+      const fiveExpired = fiveResetMs !== null && now > fiveResetMs
+      const sevenExpired = sevenResetMs !== null && now > sevenResetMs
+      // Load as not-stale — SDK event or successful poll will confirm freshness.
+      // The stale timer started by the first failed poll will mark stale if no data arrives.
+      this._claudeUsage = {
+        fiveHour:      fiveExpired  ? null : cached.fiveHour,
+        fiveHourReset: fiveExpired  ? null : cached.fiveHourReset,
+        sevenDay:      sevenExpired ? null : cached.sevenDay,
+        sevenDayReset: sevenExpired ? null : cached.sevenDayReset,
+        fiveHourStale: false,
+      }
+      this.notify()
+    } catch { /* corrupt cache — ignore, polling will populate fresh data */ }
+  }
+
+  private _clearFiveHourStaleTimer() {
+    if (this._fiveHourStaleTimer) {
+      clearTimeout(this._fiveHourStaleTimer)
+      this._fiveHourStaleTimer = null
+    }
+  }
+
+  /** Start the stale timer only if not already running and not already stale.
+   *  If the current poll interval already exceeds the stale threshold (e.g. 30min backoff or
+   *  server-directed rate limit), mark stale immediately — waiting 10min would show stale data
+   *  as fresh during a window where we know no poll is coming. */
+  private _startFiveHourStaleTimerIfNeeded() {
+    if (this._fiveHourStaleTimer !== null) return   // timer already running — don't reset
+    if (this._claudeUsage?.fiveHourStale) return    // already stale — nothing to do
+    if (this._usageCurrentInterval > WorkspaceStore._FIVE_HOUR_STALE_MS) {
+      // Next poll is further away than the stale window — no point waiting for the timer
+      const prev = this._claudeUsage ?? { fiveHour: null, sevenDay: null, fiveHourReset: null, sevenDayReset: null }
+      this._claudeUsage = { ...prev, fiveHourStale: true }
+      window.electronAPI.debug.log(`[usage:poll] stale immediately — next poll in ${this._usageCurrentInterval / 60000}min`)
+      this.notify()
+      return
+    }
+    this._fiveHourStaleTimer = setTimeout(() => {
+      this._fiveHourStaleTimer = null
+      const prev = this._claudeUsage ?? { fiveHour: null, sevenDay: null, fiveHourReset: null, sevenDayReset: null }
+      this._claudeUsage = { ...prev, fiveHourStale: true }
+      window.electronAPI.debug.log(`[usage:poll] stale — no data for ${WorkspaceStore._FIVE_HOUR_STALE_MS / 60000} min`)
+      this.notify()
+    }, WorkspaceStore._FIVE_HOUR_STALE_MS)
+  }
 
   private async _fetchUsage() {
     if (this._usageInflight) return
     this._usageInflight = true
     try {
       const u = await window.electronAPI.claude.getUsage()
-      if (!u) return
+      if (!u) {
+        // null = both auth methods returned non-OK (e.g. 401/403/5xx) — counts as a failure
+        this._startFiveHourStaleTimerIfNeeded()
+        return
+      }
 
       // Handle rate-limit response from main process
       // Use server's retryAfterSec directly — do not double existing interval,
       // since OAuth always rate-limits on Windows and exponential backoff causes 1.5h+ staleness
       if ('rateLimited' in u && (u as any).rateLimited) {
-        const retryAfterMs = ((u as any).retryAfterSec || 60) * 1000
-        this._usageCurrentInterval = Math.min(retryAfterMs, this._usageMaxInterval)
+        this._usageRateLimitStreak++
+        // cumulative backoff: 120s → 240s → 480s → 600s (10 min cap), ignores server retry-after
+        const backoffMs = Math.min(120_000 * Math.pow(2, this._usageRateLimitStreak - 1), this._usageMaxInterval)
+        this._usageCurrentInterval = backoffMs
+        this._usageRateLimited = true
+        window.electronAPI.debug.log(`[usage:poll] rate-limited (streak=${this._usageRateLimitStreak}), retry in ${Math.round(backoffMs / 1000)}s`)
+        this._startFiveHourStaleTimerIfNeeded()
         return
       }
 
-      // Success — reset to base interval
+      // Success — cancel stale timer, clear stale flag, reset poll interval
+      // Merge with existing state: prefer poll values, fall back to prior SDK event values for null fields
+      this._clearFiveHourStaleTimer()
+      this._usageRateLimited = false
+      this._usageRateLimitStreak = 0
       this._usageCurrentInterval = this._usageBaseInterval
-      this._claudeUsage = u
+      const prev = this._claudeUsage ?? { fiveHour: null, sevenDay: null, fiveHourReset: null, sevenDayReset: null }
+      const polled = u as any
+      window.electronAPI.debug.log(`[usage:poll] OK 5h=${polled.fiveHour} 7d=${polled.sevenDay} 5hReset=${polled.fiveHourReset} 7dReset=${polled.sevenDayReset}`)
+      this._claudeUsage = {
+        fiveHour:      polled.fiveHour      ?? prev.fiveHour,
+        sevenDay:      polled.sevenDay      ?? prev.sevenDay,
+        fiveHourReset: polled.fiveHourReset ?? prev.fiveHourReset,
+        sevenDayReset: polled.sevenDayReset ?? prev.sevenDayReset,
+        fiveHourStale: false,
+      }
+      this._persistUsage()
       this.notify()
     } catch {
-      // Network error — double the interval (exponential backoff)
+      // Network error — clear rate-limit flag (different failure type), double interval
+      this._usageRateLimited = false
       this._usageCurrentInterval = Math.min(this._usageCurrentInterval * 2, this._usageMaxInterval)
+      this._startFiveHourStaleTimerIfNeeded()
     } finally {
       this._usageInflight = false
     }
   }
 
   private _scheduleNextPoll() {
+    if (!this._usagePollingStarted) return
     if (this._usageTimer) clearTimeout(this._usageTimer)
     this._usageTimer = setTimeout(async () => {
       await this._fetchUsage()
@@ -72,6 +206,9 @@ class WorkspaceStore {
   startUsagePolling() {
     if (this._usagePollingStarted) return
     this._usagePollingStarted = true
+
+    // Restore last known values immediately so UI isn't blank on startup
+    this._loadPersistedUsage()
 
     // Initial fetch
     this._fetchUsage().then(() => this._scheduleNextPoll())
@@ -92,12 +229,49 @@ class WorkspaceStore {
     document.addEventListener('visibilitychange', this._visibilityHandler)
   }
 
+  /** Update usage from SDK rate_limit_event — no API call needed.
+   *  utilization may be undefined (SDK often omits it); resetsAt is usually present. */
+  applyRateLimitEvent(info: { rateLimitType: string; utilization?: number; resetsAt?: number }) {
+    const prev = this._claudeUsage ?? { fiveHour: null, sevenDay: null, fiveHourReset: null, sevenDayReset: null }
+    const resetIso = info.resetsAt ? new Date(info.resetsAt).toISOString() : null
+    if (info.rateLimitType === 'five_hour') {
+      this._clearFiveHourStaleTimer()
+      this._claudeUsage = {
+        ...prev,
+        fiveHour: info.utilization ?? prev.fiveHour,     // keep existing if SDK omits
+        fiveHourReset: resetIso ?? prev.fiveHourReset,
+        fiveHourStale: false,
+      }
+    } else if (info.rateLimitType === 'seven_day' || info.rateLimitType === 'seven_day_opus' || info.rateLimitType === 'seven_day_sonnet') {
+      this._claudeUsage = {
+        ...prev,
+        sevenDay: info.utilization ?? prev.sevenDay,
+        sevenDayReset: resetIso ?? prev.sevenDayReset,
+      }
+    }
+    this._persistUsage()
+    this.notify()
+  }
+
   /** Call after agent activity (turn completed, session ended) for a timely refresh */
   refreshUsageNow() {
     if (!this._usagePollingStarted) return
-    // Use shorter interval temporarily after activity
+    // Skip if in rate-limit backoff — hammering a rate-limited endpoint only extends the ban
+    if (this._usageRateLimited) return
+    if (this._usageTimer) { clearTimeout(this._usageTimer); this._usageTimer = null }
     this._usageCurrentInterval = this._usageMinInterval
     this._fetchUsage().then(() => this._scheduleNextPoll())
+  }
+
+  /** Release all polling resources (timers + event listeners) */
+  stopUsagePolling() {
+    if (this._usageTimer) { clearTimeout(this._usageTimer); this._usageTimer = null }
+    this._clearFiveHourStaleTimer()
+    if (this._visibilityHandler) {
+      document.removeEventListener('visibilitychange', this._visibilityHandler)
+      this._visibilityHandler = null
+    }
+    this._usagePollingStarted = false
   }
 
   getState(): AppState {
@@ -267,7 +441,7 @@ class WorkspaceStore {
   }
 
   // Terminal actions
-  addTerminal(workspaceId: string, agentPreset?: AgentPresetId): TerminalInstance {
+  addTerminal(workspaceId: string, agentPreset?: AgentPresetId, options?: { model?: string }): TerminalInstance {
     const workspace = this.state.workspaces.find(w => w.id === workspaceId)
     if (!workspace) throw new Error('Workspace not found')
 
@@ -289,7 +463,8 @@ class WorkspaceStore {
       title,
       cwd: workspace.folderPath,
       scrollbackBuffer: [],
-      lastActivityTime: Date.now()
+      lastActivityTime: Date.now(),
+      ...(options?.model ? { model: options.model } : {}),
     }
 
     // Auto-focus if it's an agent terminal or no current focus
@@ -366,23 +541,21 @@ class WorkspaceStore {
   }
 
   appendScrollback(id: string, data: string): void {
-    this.state = {
-      ...this.state,
-      terminals: this.state.terminals.map(t =>
-        t.id === id ? { ...t, scrollbackBuffer: [...t.scrollbackBuffer, data] } : t
-      )
-    }
-    // Don't notify for scrollback updates to avoid re-renders
+    // Direct mutation — no notify() means React never reads this via subscription,
+    // so immutability provides no benefit; avoids O(n) spread on every PTY data event
+    const terminal = this.state.terminals.find(t => t.id === id)
+    if (terminal) terminal.scrollbackBuffer.push(data)
   }
 
   clearScrollback(id: string): void {
+    // Immutable update + notify: clears the buffer AND triggers re-render so UI reflects empty state.
+    // Must replace the array reference so any component reading scrollbackBuffer sees the change.
     this.state = {
       ...this.state,
       terminals: this.state.terminals.map(t =>
         t.id === id ? { ...t, scrollbackBuffer: [] } : t
       )
     }
-
     this.notify()
   }
 

--- a/src/styles/claude-agent.css
+++ b/src/styles/claude-agent.css
@@ -1156,23 +1156,6 @@
   color: #ccc;
 }
 
-.claude-1m-toggle {
-  font-size: calc(var(--claude-font-size) - 3px);
-  font-weight: 600;
-  opacity: 0.4;
-  border: 1px solid rgba(255, 255, 255, 0.15);
-  border-radius: 3px;
-  padding: 0 5px;
-}
-.claude-1m-toggle:hover {
-  opacity: 0.7;
-}
-.claude-1m-toggle.active {
-  opacity: 1;
-  color: #6cf;
-  border-color: #6cf;
-}
-
 .claude-status-spacer {
   flex: 1;
 }
@@ -1684,11 +1667,24 @@
   text-decoration: underline;
 }
 
+.claude-usage-low {
+  color: #98c379;
+}
 .claude-usage-mid {
   color: #e6a700;
 }
 .claude-usage-high {
   color: #e05252;
+}
+.claude-usage-stale {
+  opacity: 0.45;
+}
+.claude-usage-overpace {
+  animation: usage-pulse 2s ease-in-out infinite;
+}
+@keyframes usage-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.5; }
 }
 
 /* ============================================

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -210,7 +210,6 @@ export interface AppSettings {
   defaultTerminalCount: number;   // 每個 workspace 預設的 terminal 數量
   createDefaultAgentTerminal: boolean;  // 是否預設建立 Agent Terminal
   allowBypassPermissions: boolean;  // 允許切換 bypassPermissions 模式時不再確認
-  enable1MContext: boolean;  // 啟用 1M token context (僅 Sonnet 4/4.5)
   defaultModel?: string;     // 預設模型（空 = 使用 SDK 預設）
   defaultEffort?: 'low' | 'medium' | 'high' | 'max';  // 預設 effort level
   showDockBadge?: boolean;               // Dock 圖示顯示待處理數量


### PR DESCRIPTION
## Summary

- **Usage polling fix**: SDK `rate_limit_event` silently dropped when `utilization` undefined — now only checks `rateLimitType`, frontend handles undefined via `??`
- **Cumulative backoff**: Replace server `retry-after` with `120s × 2^streak` (cap 10min) to prevent 1.5h+ stale data on Windows where OAuth always 429s
- **Polling guards**: Block `refreshUsageNow()` during rate-limit backoff, clear timer to prevent dual-timer race, reset flag on network error
- **Context tokens live update**: Move `contextTokens` from result event to `stream_event message_start` for real-time context % during long responses
- **5h pacing indicator**: `getUsagePacing()` compares utilization vs time-elapsed % in 5h window; UI shows ▼ (on pace) / ▲ (over pace + pulse animation) with burn rate & ETA tooltip
- **1M model variant**: Remove `enable1MContext` toggle from settings/preload/IPC/UI; 1M context now selected via model name `[1m]` suffix in dropdown
- **Context% dynamic color**: green (≤50%) / yellow (<80%) / red (≥80%) + blue 1M badge when context window ≥ 1M tokens
- **Statusline color fix**: Config custom color no longer overrides dynamic inline style colors

## Changed files (11)

| File | Change |
|------|--------|
| `electron/claude-agent-manager.ts` | rate_limit_event fix, contextTokens live, remove enable1MContext |
| `electron/preload.ts` | remove set1MContext IPC, utilization optional |
| `electron/remote/protocol.ts` | remove claude:set-1m-context channel |
| `src/stores/workspace-store.ts` | cumulative backoff, pacing, refreshUsageNow guard |
| `src/components/ClaudeAgentPanel.tsx` | 1M dropdown injection, context% color, pacing UI |
| `src/components/SettingsPanel.tsx` | remove 1M checkbox |
| `src/stores/settings-store.ts` | remove enable1MContext |
| `src/types/index.ts` | remove enable1MContext from AppSettings |
| `src/locales/en.json` | remove 1M i18n keys |
| `src/locales/zh-TW.json` | remove 1M i18n keys |
| `src/styles/claude-agent.css` | remove 1M toggle CSS, add overpace pulse animation |

## Test plan

- [ ] Verify usage polling recovers from 429 with cumulative backoff (check debug.log for `[usage:poll] rate-limited (streak=N)`)
- [ ] Verify context% updates in real-time during long responses (not only after result)
- [ ] Verify 5h pacing indicator shows ▼/▲ with correct tooltip
- [ ] Verify model dropdown includes `Claude Opus 4.6 [1M]` variant
- [ ] Verify statusline custom colors don't override context% dynamic colors
- [ ] Verify Settings panel no longer has 1M context checkbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)