### PR TITLE
feat: Firefox cookie as primary usage polling source, OAuth fallback

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,9 @@
 
 - **NEVER** break existing features when implementing new ones.
 - Before committing, verify ALL existing features still work — not just the new changes.
-- Run the build (`npx vite build`) to confirm compilation succeeds.
+- TypeScript check (faster): `node_modules/.bin/tsc.cmd --noEmit` (use forward slashes in bash)
+- Full build (Windows): `node_modules/.bin/vite.cmd build` — `npx vite build` does NOT work on this machine.
+- TSC has pre-existing errors (ElectronAPI types lag behind preload); filter by changed file names to check for new errors.
 - When modifying shared code (stores, IPC handlers, types), trace all consumers to ensure nothing breaks.
 
 ## Logging
@@ -12,7 +14,7 @@
 - **Frontend (renderer)**: Use `window.electronAPI.debug.log(...)` instead of `console.log()`. This sends logs to the electron main process logger, which writes to disk.
 - **Backend (electron)**: Use `logger.log(...)` / `logger.error(...)` from `./logger`.
 - Do NOT use `console.log()` for debugging — use the logger so logs are persisted and visible in the log file.
-- **Log file location**: `~/Library/Application Support/better-agent-terminal/debug.log`
+- **Log file location**: macOS: `~/Library/Application Support/better-agent-terminal/debug.log` / Windows: `%APPDATA%/better-agent-terminal/debug.log`
 
 ## Sub-agent / Active Tasks Tracking
 
@@ -30,4 +32,25 @@
 
 - Our status line implementation is superior to external alternatives (e.g., ccstatusline). Do not replace it.
 - 13 configurable items with custom colors, zone alignment, and template-based config.
-- Usage polling: Chrome session key (primary, lenient rate limits) → OAuth fallback (strict rate limits).
+- Usage polling: Firefox cookie (primary) → OAuth `/api/oauth/usage` (fallback).
+- Firefox `cookies.sqlite`: plaintext `value` column, query `moz_cookies` where `host LIKE '%claude.ai%' AND name = 'sessionKey'`.
+- Firefox profile resolved from `profiles.ini` (`[Install*]` → `Default=1` → `[Profile0]` fallback); supports `IsRelative` flag.
+- Firefox cookie path cached on first call; Linux supports Snap/Flatpak paths.
+- Session key cached 30 min; EBUSY (Firefox running) skips re-read for 10 min, returns stale cache.
+- Org ID fetched via `claude.ai/api/organizations` with session key cookie, cached 30 min.
+- Chrome 127+ uses App-Bound Encryption (v20/APPB) — DPAPI cannot decrypt. Chrome/Edge cookie approach removed.
+- SDK `rate_limit_event`: `utilization` is always missing (SDK omits it); only `resetsAt` is reliable.
+- OAuth rate-limit: cumulative backoff 120s→240s→480s→600s (streak counter, resets on success).
+- 5h pacing indicator compares utilization vs time-elapsed %; pure frontend calc, no extra API calls.
+
+## 1M Context
+
+- Controlled via model name suffix `[1m]` (e.g., `claude-opus-4-6[1m]`), not a separate toggle.
+- SDK sends `betas: ['context-1m-2025-08-07']` automatically when model name contains `[1m]`.
+
+## Native Modules (Electron)
+
+- `"npmRebuild": false` in `package.json` build config — electron-builder will NOT rebuild native modules.
+- Only use packages with Electron-specific prebuilts (e.g., `@lydell/node-pty`) or pure-WASM/pure-JS libs.
+- **Never add native modules** (compiled `.node` files) as regular `dependencies` — they will fail at runtime with ABI mismatch (system Node.js ABI ≠ Electron ABI).
+- Current example: `sql.js` (WASM) used instead of `better-sqlite3` (native) for cookie DB queries.

--- a/electron/claude-agent-manager.ts
+++ b/electron/claude-agent-manager.ts
@@ -124,7 +124,6 @@ interface SessionInstance {
   pendingAskUser: Map<string, PendingRequest>
   permissionMode: AppPermissionMode
   effort: 'low' | 'medium' | 'high' | 'max'
-  enable1MContext: boolean
   model?: string
   messageQueue: QueuedMessage[]
   currentPrompt?: string  // Track the currently running prompt for abort context
@@ -301,7 +300,6 @@ export class ClaudeAgentManager {
         pendingAskUser: new Map(),
         permissionMode: options.permissionMode || 'default',
         effort: options.effort || 'medium',
-        enable1MContext: false,
         model: options.model,
         messageQueue: [],
         activeTasks: new Map(),
@@ -509,6 +507,7 @@ export class ClaudeAgentManager {
       const currentMode = session.permissionMode
       // Map app-level bypassPlan to SDK's plan mode
       const sdkMode: PermissionMode = currentMode === 'bypassPlan' ? 'plan' : currentMode
+
       const queryOptions: Record<string, unknown> = {
         abortController: session.abortController,
         cwd: session.cwd,
@@ -524,7 +523,6 @@ export class ClaudeAgentManager {
         toolConfig: { askUserQuestion: { previewFormat: 'html' } },
         agentProgressSummaries: true,
         ...(session.model ? { model: session.model } : {}),
-        ...(session.enable1MContext ? { betas: ['context-1m-2025-08-07'] } : {}),
         ...(installedPlugins.length > 0 ? { plugins: installedPlugins } : {}),
         canUseTool,
         ...(claudeCodePath ? { pathToClaudeCodeExecutable: claudeCodePath } : {}),
@@ -571,6 +569,11 @@ export class ClaudeAgentManager {
         }
       }
 
+      // Debug: log query options and 1M context strategy
+      const qModel = (queryOptions as { model?: string }).model
+      const is1M = qModel?.includes('[1m]') || false
+      logger.log(`[claude:query] sessionId=${sessionId.slice(0, 8)} model=${qModel || 'default'} is1M=${is1M} resume=${resumeId?.slice(0, 8) || 'none'}`)
+
       const generator = query({
         prompt: promptArg as Parameters<typeof query>[0]['prompt'],
         options: queryOptions as Parameters<typeof query>[0]['options'],
@@ -589,7 +592,16 @@ export class ClaudeAgentManager {
           logger.log(`[claude:msg] type=${message.type} subtype=${msgSubtype || ''} parent_tool_use_id=${(message as { parent_tool_use_id?: string }).parent_tool_use_id || 'none'}`)
         }
         if (message.type === 'rate_limit_event') {
-          logger.log(`[claude:rate_limit_event] ${JSON.stringify(message)}`)
+          const msg = message as { rate_limit_info?: { rateLimitType?: string; utilization?: number; resetsAt?: number } }
+          const info = msg.rate_limit_info
+          logger.log(`[claude:rate_limit_event] type=${info?.rateLimitType ?? 'MISSING'} util=${info?.utilization ?? 'MISSING'} resetsAt=${info?.resetsAt ?? 'MISSING'} raw=${JSON.stringify(message)}`)
+          if (info?.rateLimitType) {
+            this.send('claude:usage-update', {
+              rateLimitType: info.rateLimitType,
+              utilization: info.utilization,  // may be undefined — frontend handles it
+              resetsAt: info.resetsAt,
+            })
+          }
         }
         if (message.type === 'assistant') {
           const blocks = (message as { message?: { content?: unknown[] } }).message?.content
@@ -606,9 +618,12 @@ export class ClaudeAgentManager {
 
         if (message.type === 'system' && message.subtype === 'init') {
           // Capture and persist the SDK session ID
-          const initMsg = message as { session_id: string; model?: string; cwd?: string; permissionMode?: string }
+          const initMsg = message as { session_id: string; model?: string; cwd?: string; permissionMode?: string; betas?: string[]; apiKeySource?: string }
           session.sdkSessionId = initMsg.session_id
           sdkSessionIds.set(sessionId, initMsg.session_id)
+
+          // Debug: log init response for 1M context validation
+          logger.log(`[claude:init] sessionId=${sessionId.slice(0, 8)} model=${initMsg.model} betas=${initMsg.betas ? JSON.stringify(initMsg.betas) : 'none'} apiKeySource=${initMsg.apiKeySource || 'unknown'}`)
 
           // Extract metadata from init message
           session.metadata.model = initMsg.model
@@ -783,6 +798,11 @@ export class ClaudeAgentManager {
             if (eventUsage.output_tokens && eventUsage.output_tokens > session.metadata.outputTokens) {
               session.metadata.outputTokens = eventUsage.output_tokens
             }
+            // message_start input_tokens = actual context window usage for this turn
+            if (event.type === 'message_start' && contextTokens > 0) {
+              session.metadata.contextTokens = contextTokens
+              logger.log(`[claude:ctx-live] sessionId=${sessionId.slice(0, 8)} contextTokens=${contextTokens} contextWindow=${session.metadata.contextWindow} pct=${session.metadata.contextWindow > 0 ? Math.round((contextTokens / session.metadata.contextWindow) * 100) : '?'}%`)
+            }
             this.send('claude:status', sessionId, { ...session.metadata })
           }
           if (event.type === 'content_block_delta') {
@@ -954,6 +974,8 @@ export class ClaudeAgentManager {
             logger.log(summary)
             session.metadata.inputTokens = totalInput
             session.metadata.outputTokens = totalOutput
+            // Debug: 1M context validation
+            logger.log(`[claude:1M-check] sessionId=${sessionId.slice(0, 8)} model=${session.model || 'default'} contextWindow=${session.metadata.contextWindow} is1M=${(session.metadata.contextWindow || 0) >= 1000000}`)
           } else if (resultMsg.usage) {
             const usageFull = resultMsg.usage as { input_tokens?: number; output_tokens?: number; cache_creation_input_tokens?: number; cache_read_input_tokens?: number }
             const cacheRead = usageFull.cache_read_input_tokens || 0
@@ -963,11 +985,6 @@ export class ClaudeAgentManager {
             logger.log(line)
             session.metadata.inputTokens = totalInput
             session.metadata.outputTokens = usageFull.output_tokens || 0
-          }
-
-          // Per-turn usage.input_tokens reflects actual current context size
-          if (resultMsg.usage?.input_tokens) {
-            session.metadata.contextTokens = resultMsg.usage.input_tokens
           }
 
           this.send('claude:status', sessionId, { ...session.metadata })
@@ -1196,13 +1213,6 @@ export class ClaudeAgentManager {
     const session = this.sessions.get(sessionId)
     if (!session) return false
     session.effort = effort
-    return true
-  }
-
-  set1MContext(sessionId: string, enable: boolean): boolean {
-    const session = this.sessions.get(sessionId)
-    if (!session) return false
-    session.enable1MContext = enable
     return true
   }
 
@@ -1580,7 +1590,6 @@ export class ClaudeAgentManager {
     const cwd = session.cwd
     const permissionMode = session.permissionMode
     const effort = session.effort
-    const enable1MContext = session.enable1MContext
     const model = session.model
 
     // Tear down old session completely
@@ -1591,15 +1600,7 @@ export class ClaudeAgentManager {
     sdkSessionIds.delete(sessionId)
 
     // Start a fresh session preserving settings
-    const ok = await this.startSession(sessionId, { cwd, permissionMode })
-    if (ok) {
-      const newSession = this.sessions.get(sessionId)
-      if (newSession) {
-        newSession.effort = effort
-        newSession.enable1MContext = enable1MContext
-        newSession.model = model
-      }
-    }
+    const ok = await this.startSession(sessionId, { cwd, permissionMode, effort, model })
     // Notify all windows to clear UI for this session
     this.send('claude:session-reset', sessionId)
     return ok

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,5 +1,6 @@
 import { app, BrowserWindow, ipcMain, dialog, shell, Menu, powerMonitor, clipboard, nativeImage } from 'electron'
 import path from 'path'
+import os from 'os'
 import * as fs from 'fs/promises'
 import * as fsSync from 'fs'
 import { execFileSync } from 'child_process'
@@ -447,7 +448,6 @@ function registerProxiedHandlers() {
   registerHandler('claude:set-permission-mode', (sessionId: string, mode: string) => claudeManager?.setPermissionMode(sessionId, mode as import('@anthropic-ai/claude-agent-sdk').PermissionMode))
   registerHandler('claude:set-model', (sessionId: string, model: string) => claudeManager?.setModel(sessionId, model))
   registerHandler('claude:set-effort', (sessionId: string, effort: string) => claudeManager?.setEffort(sessionId, effort as 'low' | 'medium' | 'high' | 'max'))
-  registerHandler('claude:set-1m-context', (sessionId: string, enable: boolean) => claudeManager?.set1MContext(sessionId, enable))
   registerHandler('claude:reset-session', (sessionId: string) => claudeManager?.resetSession(sessionId))
   registerHandler('claude:get-supported-models', (sessionId: string) => claudeManager?.getSupportedModels(sessionId))
   registerHandler('claude:get-account-info', (sessionId: string) => claudeManager?.getAccountInfo(sessionId))
@@ -520,17 +520,275 @@ function registerProxiedHandlers() {
     return true
   })
 
-  // Claude usage (5h / 7d rate limits)
-  // Primary: session key from Chrome cookies (lenient rate limits on claude.ai)
-  // Fallback: OAuth token from Claude Code credentials (strict rate limits on api.anthropic.com)
+  // Claude usage (5h / 7d rate limits) — Firefox cookie → OAuth fallback
+  // Firefox cookies.sqlite stores sessionKey in plaintext (no decryption needed)
+  // Chrome 127+ uses App-Bound Encryption (v20) — not viable, OAuth as fallback
   let _cachedOAuthToken: string | null = null
-  let _cachedSessionKey: string | null = null
-  let _cachedOrgId: string | null = null
-  let _cachedCfClearance: string | null = null
   let _tokenCacheTime = 0
+  const TOKEN_CACHE_TTL = 10 * 60 * 1000
+
+  // --- Firefox cookie-based usage polling (primary source) ---
+
+  let _cachedCookiesPath: string | null | undefined = undefined // undefined = not yet resolved
+
+  /** Resolve Firefox default profile cookies.sqlite path cross-platform (cached on first call) */
+  async function getFirefoxCookiePath(): Promise<string | null> {
+    if (_cachedCookiesPath !== undefined) return _cachedCookiesPath
+
+    try {
+      // Linux: try standard, Snap, Flatpak paths
+      const profilesDirs: string[] = []
+      if (process.platform === 'win32') {
+        profilesDirs.push(path.join(process.env.APPDATA || path.join(os.homedir(), 'AppData', 'Roaming'), 'Mozilla', 'Firefox'))
+      } else if (process.platform === 'darwin') {
+        profilesDirs.push(path.join(os.homedir(), 'Library', 'Application Support', 'Firefox'))
+      } else {
+        profilesDirs.push(path.join(os.homedir(), '.mozilla', 'firefox'))
+        profilesDirs.push(path.join(os.homedir(), 'snap', 'firefox', 'common', '.mozilla', 'firefox'))
+        profilesDirs.push(path.join(os.homedir(), '.var', 'app', 'org.mozilla.firefox', '.mozilla', 'firefox'))
+      }
+
+      for (const profilesDir of profilesDirs) {
+        const result = await _resolveFirefoxProfile(profilesDir)
+        if (result) {
+          _cachedCookiesPath = result
+          logger.log('[usage] Firefox cookies.sqlite path:', result)
+          return result
+        }
+      }
+
+      _cachedCookiesPath = null
+      return null
+    } catch {
+      _cachedCookiesPath = null
+      return null
+    }
+  }
+
+  async function _resolveFirefoxProfile(profilesDir: string): Promise<string | null> {
+    try {
+
+      const iniPath = path.join(profilesDir, 'profiles.ini')
+      const iniContent = await fs.readFile(iniPath, 'utf-8')
+      const lines = iniContent.split(/\r?\n/)
+
+      // Parse INI into sections
+      const sections: Record<string, Record<string, string>> = {}
+      let currentSection = ''
+      for (const line of lines) {
+        const sectionMatch = line.match(/^\[(.+)\]$/)
+        if (sectionMatch) {
+          currentSection = sectionMatch[1]
+          sections[currentSection] = {}
+        } else if (currentSection) {
+          const kvMatch = line.match(/^([^=]+)=(.*)$/)
+          if (kvMatch) sections[currentSection][kvMatch[1].trim()] = kvMatch[2].trim()
+        }
+      }
+
+      // Find profile path priority:
+      // 1. [Install*] section Default= (Firefox's actual active profile path)
+      // 2. [Profile*] section with Default=1
+      // 3. [Profile0] fallback
+      let profilePath: string | null = null
+      let isRelative = true
+
+      // 1. Check [Install*] sections — these point to the actively-used profile
+      //    [Install*] Default= is always relative to profilesDir (no IsRelative key)
+      for (const [name, props] of Object.entries(sections)) {
+        if (name.startsWith('Install') && props['Default']) {
+          profilePath = props['Default']
+          isRelative = true
+          break
+        }
+      }
+
+      // 2. Fall back to section with Default=1
+      if (!profilePath) {
+        for (const [, props] of Object.entries(sections)) {
+          if (props['Default'] === '1' && props['Path']) {
+            profilePath = props['Path']
+            isRelative = props['IsRelative'] !== '0'
+            break
+          }
+        }
+      }
+
+      // 3. Fall back to Profile0
+      if (!profilePath && sections['Profile0']?.['Path']) {
+        profilePath = sections['Profile0']['Path']
+        isRelative = sections['Profile0']['IsRelative'] !== '0'
+      }
+
+      if (!profilePath) return null
+
+      const fullProfilePath = isRelative ? path.join(profilesDir, profilePath) : profilePath
+      const cookiesPath = path.join(fullProfilePath, 'cookies.sqlite')
+
+      // Verify file exists
+      await fs.access(cookiesPath)
+      return cookiesPath
+    } catch {
+      return null
+    }
+  }
+
+
+
+  let _sqlJs: any = null // cached sql.js WASM instance
+  let _cachedSessionKey: string | null = null
   let _sessionKeyCacheTime = 0
-  const TOKEN_CACHE_TTL = 10 * 60 * 1000     // 10 minutes
-  const SESSION_KEY_CACHE_TTL = 30 * 60 * 1000 // 30 minutes
+  const SESSION_KEY_CACHE_TTL = 30 * 60 * 1000
+  let _firefoxSkipUntil = 0
+
+  /** Extract sessionKey cookie from Firefox cookies.sqlite via sql.js (WASM) */
+  async function getSessionKeyFromFirefox(): Promise<string | null> {
+    const now = Date.now()
+    if (_cachedSessionKey && now - _sessionKeyCacheTime < SESSION_KEY_CACHE_TTL) {
+      return _cachedSessionKey
+    }
+    if (now < _firefoxSkipUntil) {
+      return _cachedSessionKey // stale or null
+    }
+
+    const cookiesPath = await getFirefoxCookiePath()
+    if (!cookiesPath) return null
+
+    try {
+      if (!_sqlJs) {
+        const initSqlJs = (await import('sql.js')).default
+        _sqlJs = await initSqlJs()
+      }
+      const buf = await fs.readFile(cookiesPath)
+      const db = new _sqlJs.Database(new Uint8Array(buf))
+      try {
+        const result = db.exec(
+          "SELECT value FROM moz_cookies WHERE host LIKE '%claude.ai%' AND name = 'sessionKey' LIMIT 1"
+        )
+        if (result.length > 0 && result[0].values.length > 0) {
+          const value = String(result[0].values[0][0])
+          if (value) {
+            _cachedSessionKey = value
+            _sessionKeyCacheTime = now
+            logger.log('[usage] Extracted session key from Firefox (length:', value.length, ')')
+            return value
+          }
+        }
+        logger.log('[usage] Firefox cookies.sqlite found but no sessionKey cookie')
+        return null
+      } finally {
+        db.close()
+      }
+    } catch (e: unknown) {
+      const err = e as NodeJS.ErrnoException
+      if (err.code === 'EBUSY') {
+        _firefoxSkipUntil = now + 10 * 60 * 1000
+        logger.log('[usage] Firefox cookies.sqlite is locked (EBUSY), skipping for 10 min')
+        return _cachedSessionKey
+      }
+      logger.log('[usage] Firefox cookie read error:', err.message)
+      return null
+    }
+  }
+
+  let _cachedOrgId: string | null = null
+  let _orgIdCacheTime = 0
+  const ORG_ID_CACHE_TTL = 30 * 60 * 1000
+  let _orgIdForSessionKey: string | null = null
+
+  function getChromeUserAgent(): string {
+    if (process.platform === 'darwin') {
+      return 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36'
+    }
+    if (process.platform === 'linux') {
+      return 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36'
+    }
+    return 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36'
+  }
+
+  /** Fetch org ID from Claude API using session cookie */
+  async function getOrgId(sessionKey: string): Promise<string | null> {
+    const now = Date.now()
+    if (_cachedOrgId && now - _orgIdCacheTime < ORG_ID_CACHE_TTL && _orgIdForSessionKey === sessionKey) {
+      return _cachedOrgId
+    }
+    try {
+      const res = await fetch('https://claude.ai/api/organizations', {
+        headers: {
+          'Cookie': `sessionKey=${sessionKey}`,
+          'User-Agent': getChromeUserAgent(),
+          'Accept': 'application/json',
+        },
+      })
+
+      if (res.status === 401 || res.status === 403) {
+        _cachedSessionKey = null
+        _sessionKeyCacheTime = 0
+        _cachedOrgId = null
+        _orgIdCacheTime = 0
+        _orgIdForSessionKey = null
+        logger.log('[usage] [session] org fetch auth error', res.status, '— cleared caches')
+        return null
+      }
+
+      if (!res.ok) return null
+
+      const orgs = await res.json() as any[]
+      const uuid = orgs?.[0]?.uuid
+      if (!uuid) return null
+
+      _cachedOrgId = uuid
+      _orgIdCacheTime = now
+      _orgIdForSessionKey = sessionKey
+      return uuid
+    } catch (err) {
+      logger.log('[usage] [session] org fetch failed:', err)
+      return null
+    }
+  }
+
+  /** Fetch usage via Firefox session cookie (primary source) */
+  async function fetchUsageViaSessionKey(): Promise<{ fiveHour: number | null; sevenDay: number | null; fiveHourReset: string | null; sevenDayReset: string | null } | null> {
+    const sessionKey = await getSessionKeyFromFirefox()
+    if (!sessionKey) return null
+
+    const orgId = await getOrgId(sessionKey)
+    if (!orgId) return null
+
+    try {
+      const res = await fetch(`https://claude.ai/api/organizations/${orgId}/usage`, {
+        headers: {
+          'Cookie': `sessionKey=${sessionKey}`,
+          'User-Agent': getChromeUserAgent(),
+          'Accept': 'application/json',
+        },
+      })
+
+      if (res.status === 401 || res.status === 403) {
+        _cachedSessionKey = null
+        _sessionKeyCacheTime = 0
+        _cachedOrgId = null
+        _orgIdCacheTime = 0
+        _orgIdForSessionKey = null
+        logger.log('[usage] [session] usage fetch auth error', res.status, '— cleared caches')
+        return null
+      }
+
+      if (!res.ok) return null
+
+      const data = await res.json() as any
+      logger.log('[usage] [session] 5h=', data.five_hour?.utilization, '7d=', data.seven_day?.utilization)
+      return {
+        fiveHour: data.five_hour?.utilization ?? null,
+        sevenDay: data.seven_day?.utilization ?? null,
+        fiveHourReset: data.five_hour?.resets_at ?? null,
+        sevenDayReset: data.seven_day?.resets_at ?? null,
+      }
+    } catch (err) {
+      logger.log('[usage] [session] usage fetch failed:', err)
+      return null
+    }
+  }
 
   async function getOAuthToken(): Promise<string | null> {
     const now = Date.now()
@@ -563,171 +821,8 @@ function registerProxiedHandlers() {
     } catch { return null }
   }
 
-  /** Decrypt a Chrome v10 encrypted cookie value on macOS */
-  function decryptChromeCookie(encHex: string, derivedKey: Buffer): string | null {
-    try {
-      const crypto = require('crypto')
-      const encBuf = Buffer.from(encHex, 'hex')
-      if (encBuf.length < 4 || encBuf.toString('utf-8', 0, 3) !== 'v10') return null
-      const ciphertext = encBuf.subarray(3)
-      const iv = Buffer.alloc(16, 0x20) // 16 space characters
-      const decipher = crypto.createDecipheriv('aes-128-cbc', derivedKey, iv)
-      let dec = decipher.update(ciphertext)
-      dec = Buffer.concat([dec, decipher.final()])
-      return dec.toString('utf-8').replace(/[\x00-\x1f]/g, '').trim()
-    } catch { return null }
-  }
-
-  /** Extract session key and cf_clearance from Chrome cookies on macOS */
-  async function getSessionKeyFromChrome(): Promise<{ sessionKey: string; cfClearance: string | null } | null> {
-    if (process.platform !== 'darwin') return null
-    const now = Date.now()
-    if (_cachedSessionKey && now - _sessionKeyCacheTime < SESSION_KEY_CACHE_TTL) {
-      return { sessionKey: _cachedSessionKey, cfClearance: _cachedCfClearance }
-    }
-    try {
-      const crypto = await import('crypto')
-      const { execSync } = await import('child_process')
-      const os = await import('os')
-
-      // Copy Chrome cookies DB to temp to avoid WAL lock
-      const chromeCookiePath = path.join(app.getPath('home'), 'Library/Application Support/Google/Chrome/Default/Cookies')
-      try { await fs.access(chromeCookiePath) } catch { return null }
-
-      const tmpDir = os.tmpdir()
-      const tmpDb = path.join(tmpDir, 'bat-chrome-cookies.db')
-      await fs.copyFile(chromeCookiePath, tmpDb)
-      // Also copy WAL and SHM files for consistency
-      try { await fs.copyFile(chromeCookiePath + '-wal', tmpDb + '-wal') } catch { /* ok */ }
-      try { await fs.copyFile(chromeCookiePath + '-shm', tmpDb + '-shm') } catch { /* ok */ }
-
-      // Get Chrome safe storage password from Keychain
-      const chromePassword = execSync(
-        'security find-generic-password -s "Chrome Safe Storage" -w 2>/dev/null',
-        { encoding: 'utf-8', timeout: 3000 }
-      ).trim()
-      if (!chromePassword) return null
-
-      const derivedKey = crypto.pbkdf2Sync(chromePassword, 'saltysalt', 1003, 16, 'sha1')
-
-      // Query sessionKey and cf_clearance
-      const rawOutput = execSync(
-        `sqlite3 "${tmpDb}" "SELECT name, hex(encrypted_value) FROM cookies WHERE host_key LIKE '%claude.ai%' AND name IN ('sessionKey','cf_clearance');"`,
-        { encoding: 'utf-8', timeout: 5000 }
-      ).trim()
-
-      // Clean up temp files
-      try { await fs.unlink(tmpDb) } catch { /* ok */ }
-      try { await fs.unlink(tmpDb + '-wal') } catch { /* ok */ }
-      try { await fs.unlink(tmpDb + '-shm') } catch { /* ok */ }
-
-      if (!rawOutput) return null
-
-      let sessionKey: string | null = null
-      let cfClearance: string | null = null
-
-      for (const line of rawOutput.split('\n')) {
-        const [name, hex] = line.split('|')
-        if (!hex) continue
-        const decrypted = decryptChromeCookie(hex, derivedKey as unknown as Buffer)
-        if (!decrypted) continue
-
-        // Strip non-ASCII chars from decrypted values
-        const cleaned = decrypted.replace(/[^\x20-\x7E]/g, '').trim()
-        if (name === 'sessionKey') {
-          // Decrypted value may have garbage prefix; extract from sk-ant-sid
-          const idx = cleaned.indexOf('sk-ant-sid')
-          sessionKey = idx >= 0 ? cleaned.substring(idx) : cleaned
-        } else if (name === 'cf_clearance') {
-          cfClearance = cleaned
-        }
-      }
-
-      if (!sessionKey || sessionKey.length < 10) return null
-
-      _cachedSessionKey = sessionKey
-      _cachedCfClearance = cfClearance
-      _sessionKeyCacheTime = now
-      logger.log('[usage] Extracted session key from Chrome (length:', sessionKey.length, ')')
-      return { sessionKey, cfClearance }
-    } catch (e) {
-      logger.error('[usage] Failed to extract Chrome session key:', e)
-      return null
-    }
-  }
-
-  /** Auto-detect organization ID using session key */
-  async function getOrgId(sessionKey: string, cfClearance: string | null): Promise<string | null> {
-    if (_cachedOrgId) return _cachedOrgId
-    try {
-      const cookieParts = [`sessionKey=${sessionKey}`]
-      if (cfClearance) cookieParts.push(`cf_clearance=${cfClearance}`)
-
-      const res = await fetch('https://claude.ai/api/organizations', {
-        headers: {
-          'Accept': 'application/json',
-          'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36',
-          'Cookie': cookieParts.join('; '),
-        },
-      })
-      if (!res.ok) {
-        logger.error('[usage] Organizations API returned', res.status)
-        return null
-      }
-      const orgs = await res.json()
-      if (!Array.isArray(orgs) || orgs.length === 0) {
-        logger.error('[usage] No organizations found')
-        return null
-      }
-      _cachedOrgId = orgs[0].uuid
-      logger.log('[usage] Auto-detected org ID:', _cachedOrgId)
-      return _cachedOrgId
-    } catch (e) {
-      logger.error('[usage] getOrgId failed:', e)
-      return null
-    }
-  }
-
-  /** Fetch usage via session key (primary — lenient rate limits) */
-  async function fetchUsageViaSessionKey(): Promise<{ fiveHour: number | null; sevenDay: number | null; fiveHourReset: string | null; sevenDayReset: string | null } | null> {
-    const creds = await getSessionKeyFromChrome()
-    if (!creds) return null
-    const orgId = await getOrgId(creds.sessionKey, creds.cfClearance)
-    if (!orgId) return null
-
-    const cookieParts = [`sessionKey=${creds.sessionKey}`]
-    if (creds.cfClearance) cookieParts.push(`cf_clearance=${creds.cfClearance}`)
-
-    const res = await fetch(`https://claude.ai/api/organizations/${orgId}/usage`, {
-      headers: {
-        'Accept': 'application/json',
-        'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36',
-        'Cookie': cookieParts.join('; '),
-      },
-    })
-
-    if (res.status === 401 || res.status === 403) {
-      _cachedSessionKey = null
-      _cachedOrgId = null
-      _cachedCfClearance = null
-      _sessionKeyCacheTime = 0
-      logger.log('[usage] Session key expired or blocked, will re-extract')
-      return null
-    }
-    if (!res.ok) return null
-
-    const data = await res.json()
-    logger.log('[usage] [session-key] 5h=', data.five_hour?.utilization, 'reset=', data.five_hour?.resets_at, '7d=', data.seven_day?.utilization, 'reset=', data.seven_day?.resets_at)
-    return {
-      fiveHour: data.five_hour?.utilization ?? null,
-      sevenDay: data.seven_day?.utilization ?? null,
-      fiveHourReset: data.five_hour?.resets_at ?? null,
-      sevenDayReset: data.seven_day?.resets_at ?? null,
-    }
-  }
-
-  /** Fetch usage via OAuth (fallback — strict rate limits) */
-  async function fetchUsageViaOAuth(): Promise<{ fiveHour: number | null; sevenDay: number | null; fiveHourReset: string | null; sevenDayReset: string | null } | 'rateLimited' | null> {
+  /** Fetch usage via OAuth usage endpoint */
+  async function fetchUsageViaOAuth(): Promise<{ fiveHour: number | null; sevenDay: number | null; fiveHourReset: string | null; sevenDayReset: string | null } | { rateLimited: true; retryAfterSec: number } | null> {
     const token = await getOAuthToken()
     if (!token) return null
 
@@ -740,7 +835,20 @@ function registerProxiedHandlers() {
       },
     })
 
-    if (res.status === 429) return 'rateLimited'
+    if (res.status === 429) {
+      const raw = parseInt(res.headers.get('retry-after') ?? '', 10)
+      const retryAfterSec = Number.isFinite(raw) && raw > 0 ? raw : 120
+      logger.log('[usage] [oauth] rate-limited, retry-after:', retryAfterSec, 's')
+      return { rateLimited: true, retryAfterSec }
+    }
+
+    if (res.status === 401 || res.status === 403) {
+      _cachedOAuthToken = null
+      _tokenCacheTime = 0
+      logger.log('[usage] [oauth] auth error', res.status, '— cleared token cache')
+      return null
+    }
+
     if (!res.ok) return null
 
     const data = await res.json()
@@ -755,15 +863,13 @@ function registerProxiedHandlers() {
 
   registerHandler('claude:get-usage', async () => {
     try {
-      // Try session key first (lenient rate limits on claude.ai)
+      // Primary: Firefox session key (plaintext cookie, no decryption)
       const sessionResult = await fetchUsageViaSessionKey()
       if (sessionResult) return sessionResult
 
-      // Fall back to OAuth (strict rate limits on api.anthropic.com)
+      // Fallback: OAuth token
       const oauthResult = await fetchUsageViaOAuth()
-      if (oauthResult === 'rateLimited') {
-        return { rateLimited: true, retryAfterSec: 120 }
-      }
+      if (oauthResult && 'rateLimited' in oauthResult) return oauthResult
       return oauthResult
     } catch (e) {
       logger.error('[usage] get-usage failed:', e)

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -115,14 +115,17 @@ const electronAPI = {
       ipcRenderer.on('claude:modeChange', handler)
       return () => ipcRenderer.removeListener('claude:modeChange', handler)
     },
+    onUsageUpdate: (callback: (info: { rateLimitType: string; utilization?: number; resetsAt?: number }) => void) => {
+      const handler = (_event: Electron.IpcRendererEvent, info: { rateLimitType: string; utilization?: number; resetsAt?: number }) => callback(info)
+      ipcRenderer.on('claude:usage-update', handler)
+      return () => ipcRenderer.removeListener('claude:usage-update', handler)
+    },
     setPermissionMode: (sessionId: string, mode: string) =>
       ipcRenderer.invoke('claude:set-permission-mode', sessionId, mode),
     setModel: (sessionId: string, model: string) =>
       ipcRenderer.invoke('claude:set-model', sessionId, model),
     setEffort: (sessionId: string, effort: string) =>
       ipcRenderer.invoke('claude:set-effort', sessionId, effort),
-    set1MContext: (sessionId: string, enable: boolean) =>
-      ipcRenderer.invoke('claude:set-1m-context', sessionId, enable),
     resetSession: (sessionId: string) =>
       ipcRenderer.invoke('claude:reset-session', sessionId),
     getSupportedModels: (sessionId: string) =>

--- a/electron/remote/protocol.ts
+++ b/electron/remote/protocol.ts
@@ -16,7 +16,7 @@ export const PROXIED_CHANNELS = new Set([
   'pty:create', 'pty:write', 'pty:resize', 'pty:kill', 'pty:restart', 'pty:get-cwd',
   // Claude
   'claude:start-session', 'claude:send-message', 'claude:stop-session',
-  'claude:set-permission-mode', 'claude:set-model', 'claude:set-effort', 'claude:set-1m-context', 'claude:reset-session',
+  'claude:set-permission-mode', 'claude:set-model', 'claude:set-effort', 'claude:reset-session',
   'claude:get-supported-models', 'claude:get-account-info', 'claude:get-supported-commands', 'claude:get-session-meta',
   'claude:resolve-permission', 'claude:resolve-ask-user',
   'claude:list-sessions', 'claude:resume-session', 'claude:fork-session', 'claude:stop-task', 'claude:rest-session',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "better-agent-terminal",
-  "version": "2.0.9",
+  "version": "2.1.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "better-agent-terminal",
-      "version": "2.0.9",
+      "version": "2.1.3",
       "hasInstallScript": true,
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.81",
@@ -17,7 +17,6 @@
         "@xterm/addon-unicode11": "^0.8.0",
         "@xterm/addon-web-links": "^0.11.0",
         "@xterm/xterm": "^5.5.0",
-        "better-sqlite3": "^12.5.0",
         "dompurify": "^3.3.3",
         "highlight.js": "^11.11.1",
         "i18next": "^25.8.18",
@@ -27,14 +26,15 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-i18next": "^16.5.8",
+        "sql.js": "^1.12.0",
         "uuid": "^9.0.0",
         "ws": "^8.19.0"
       },
       "devDependencies": {
-        "@types/better-sqlite3": "^7.6.13",
         "@types/node": "^20.0.0",
         "@types/react": "^18.2.0",
         "@types/react-dom": "^18.2.0",
+        "@types/sql.js": "^1.4.9",
         "@types/uuid": "^9.0.0",
         "@types/ws": "^8.18.1",
         "@vitejs/plugin-react": "^4.2.0",
@@ -1304,7 +1304,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1321,7 +1320,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1338,7 +1336,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1355,7 +1352,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1423,7 +1419,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1440,7 +1435,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1457,7 +1451,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2504,16 +2497,6 @@
         "@babel/types": "^7.28.2"
       }
     },
-    "node_modules/@types/better-sqlite3": {
-      "version": "7.6.13",
-      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
-      "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/cacheable-request": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
@@ -2799,6 +2782,13 @@
         "@types/trusted-types": "*"
       }
     },
+    "node_modules/@types/emscripten": {
+      "version": "1.41.5",
+      "resolved": "https://registry.npmjs.org/@types/emscripten/-/emscripten-1.41.5.tgz",
+      "integrity": "sha512-cMQm7pxu6BxtHyqJ7mQZ2kXWV5SLmugybFdHCBbJ5eHzOo6VhBckEgAT3//rP5FwPHNPeEiq4SmQ5ucBwsOo4Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -2911,6 +2901,17 @@
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/sql.js": {
+      "version": "1.4.11",
+      "resolved": "https://registry.npmjs.org/@types/sql.js/-/sql.js-1.4.11.tgz",
+      "integrity": "sha512-QXIx38p2ZThJaK9vP5ZdqdlRe1FG9I8SmCZOS7FHfB/2qPAjZwkL7/vlfPg6N/oWHuuOaGg/P/IRwfP2W0kWVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/emscripten": "*",
         "@types/node": "*"
       }
     },
@@ -3373,6 +3374,7 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3399,34 +3401,13 @@
         "baseline-browser-mapping": "dist/cli.js"
       }
     },
-    "node_modules/better-sqlite3": {
-      "version": "12.5.0",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.5.0.tgz",
-      "integrity": "sha512-WwCZ/5Diz7rsF29o27o0Gcc1Du+l7Zsv7SYtVPG0X3G/uUI1LqdxrQI7c9Hs2FWpqXXERjW9hp6g3/tH7DlVKg==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "bindings": "^1.5.0",
-        "prebuild-install": "^7.1.1"
-      },
-      "engines": {
-        "node": "20.x || 22.x || 23.x || 24.x || 25.x"
-      }
-    },
-    "node_modules/bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "license": "MIT",
-      "dependencies": {
-        "file-uri-to-path": "1.0.0"
-      }
-    },
     "node_modules/bl": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
       "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "buffer": "^5.5.0",
         "inherits": "^2.0.4",
@@ -3507,6 +3488,7 @@
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
       "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4671,6 +4653,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
       "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mimic-response": "^3.1.0"
@@ -4686,21 +4669,13 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
       "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/deep-extend": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0.0"
       }
     },
     "node_modules/defer-to-connect": {
@@ -4774,6 +4749,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -5212,6 +5188,7 @@
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
       "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
@@ -5354,15 +5331,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/expand-template": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
-      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
-      "license": "(MIT OR WTFPL)",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/extract-zip": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
@@ -5418,12 +5386,6 @@
       "dependencies": {
         "pend": "~1.2.0"
       }
-    },
-    "node_modules/file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "license": "MIT"
     },
     "node_modules/filelist": {
       "version": "1.0.4",
@@ -5499,7 +5461,9 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-      "license": "MIT"
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/fs-extra": {
       "version": "8.1.0",
@@ -5621,12 +5585,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/github-from-package": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
-      "license": "MIT"
     },
     "node_modules/glob": {
       "version": "7.2.3",
@@ -5994,6 +5952,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6026,12 +5985,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "license": "ISC"
-    },
-    "node_modules/ini": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/internmap": {
@@ -6581,6 +6535,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -6608,12 +6563,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/mkdirp-classic": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-      "license": "MIT"
     },
     "node_modules/mlly": {
       "version": "1.8.2",
@@ -6651,12 +6600,6 @@
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
-    },
-    "node_modules/napi-build-utils": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
-      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
-      "license": "MIT"
     },
     "node_modules/node-addon-api": {
       "version": "1.7.2",
@@ -6712,6 +6655,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -6964,44 +6908,6 @@
         "node": "^10 || ^12 || >=14"
       }
     },
-    "node_modules/prebuild-install": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
-      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
-      "license": "MIT",
-      "dependencies": {
-        "detect-libc": "^2.0.0",
-        "expand-template": "^2.0.3",
-        "github-from-package": "0.0.0",
-        "minimist": "^1.2.3",
-        "mkdirp-classic": "^0.5.3",
-        "napi-build-utils": "^2.0.0",
-        "node-abi": "^3.3.0",
-        "pump": "^3.0.0",
-        "rc": "^1.2.7",
-        "simple-get": "^4.0.0",
-        "tar-fs": "^2.0.0",
-        "tunnel-agent": "^0.6.0"
-      },
-      "bin": {
-        "prebuild-install": "bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/prebuild-install/node_modules/node-abi": {
-      "version": "3.85.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.85.0.tgz",
-      "integrity": "sha512-zsFhmbkAzwhTft6nd3VxcG0cvJsT70rL+BIGHWVq5fi6MwGrHwzqKaxXE+Hl2GmnGItnDKPPkO5/LQqjVkIdFg==",
-      "license": "MIT",
-      "dependencies": {
-        "semver": "^7.3.5"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -7038,6 +6944,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
       "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "end-of-stream": "^1.1.0",
@@ -7159,21 +7066,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/rc": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
-      "dependencies": {
-        "deep-extend": "^0.6.0",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
-      },
-      "bin": {
-        "rc": "cli.js"
-      }
-    },
     "node_modules/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
@@ -7258,7 +7150,9 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -7426,6 +7320,7 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -7440,7 +7335,8 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -7478,6 +7374,7 @@
       "version": "7.7.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
       "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -7598,51 +7495,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/simple-concat": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/simple-get": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
-      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "decompress-response": "^6.0.0",
-        "once": "^1.3.1",
-        "simple-concat": "^1.0.0"
-      }
-    },
     "node_modules/simple-update-notifier": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
@@ -7729,6 +7581,12 @@
       "license": "BSD-3-Clause",
       "optional": true
     },
+    "node_modules/sql.js": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/sql.js/-/sql.js-1.14.1.tgz",
+      "integrity": "sha512-gcj8zBWU5cFsi9WUP+4bFNXAyF1iRpA3LLyS/DP5xlrNzGmPIizUeBggKa8DbDwdqaKwUcTEnChtd2grWo/x/A==",
+      "license": "MIT"
+    },
     "node_modules/stat-mode": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-1.0.0.tgz",
@@ -7743,7 +7601,9 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
@@ -7804,15 +7664,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/strip-json-comments": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/stylis": {
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.6.tgz",
@@ -7866,29 +7717,13 @@
         "node": ">=10"
       }
     },
-    "node_modules/tar-fs": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
-      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
-      "license": "MIT",
-      "dependencies": {
-        "chownr": "^1.1.1",
-        "mkdirp-classic": "^0.5.2",
-        "pump": "^3.0.0",
-        "tar-stream": "^2.1.4"
-      }
-    },
-    "node_modules/tar-fs/node_modules/chownr": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-      "license": "ISC"
-    },
     "node_modules/tar-stream": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
       "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "bl": "^4.0.3",
         "end-of-stream": "^1.4.1",
@@ -8128,18 +7963,6 @@
       "dev": true,
       "license": "0BSD"
     },
-    "node_modules/tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/type-fest": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
@@ -8251,7 +8074,9 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "license": "MIT"
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/uuid": {
       "version": "9.0.1",
@@ -8492,6 +8317,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/ws": {
@@ -9402,28 +9228,24 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
       "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
-      "dev": true,
       "optional": true
     },
     "@img/sharp-libvips-darwin-x64": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
       "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
-      "dev": true,
       "optional": true
     },
     "@img/sharp-libvips-linux-arm": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
       "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
-      "dev": true,
       "optional": true
     },
     "@img/sharp-libvips-linux-arm64": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
       "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
-      "dev": true,
       "optional": true
     },
     "@img/sharp-libvips-linux-ppc64": {
@@ -9451,21 +9273,18 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
       "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
-      "dev": true,
       "optional": true
     },
     "@img/sharp-libvips-linuxmusl-arm64": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
       "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
-      "dev": true,
       "optional": true
     },
     "@img/sharp-libvips-linuxmusl-x64": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
       "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
-      "dev": true,
       "optional": true
     },
     "@img/sharp-linux-arm": {
@@ -10053,15 +9872,6 @@
         "@babel/types": "^7.28.2"
       }
     },
-    "@types/better-sqlite3": {
-      "version": "7.6.13",
-      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
-      "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "@types/cacheable-request": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
@@ -10313,6 +10123,12 @@
         "@types/trusted-types": "*"
       }
     },
+    "@types/emscripten": {
+      "version": "1.41.5",
+      "resolved": "https://registry.npmjs.org/@types/emscripten/-/emscripten-1.41.5.tgz",
+      "integrity": "sha512-cMQm7pxu6BxtHyqJ7mQZ2kXWV5SLmugybFdHCBbJ5eHzOo6VhBckEgAT3//rP5FwPHNPeEiq4SmQ5ucBwsOo4Q==",
+      "dev": true
+    },
     "@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -10410,6 +10226,16 @@
       "integrity": "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==",
       "dev": true,
       "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/sql.js": {
+      "version": "1.4.11",
+      "resolved": "https://registry.npmjs.org/@types/sql.js/-/sql.js-1.4.11.tgz",
+      "integrity": "sha512-QXIx38p2ZThJaK9vP5ZdqdlRe1FG9I8SmCZOS7FHfB/2qPAjZwkL7/vlfPg6N/oWHuuOaGg/P/IRwfP2W0kWVQ==",
+      "dev": true,
+      "requires": {
+        "@types/emscripten": "*",
         "@types/node": "*"
       }
     },
@@ -10762,7 +10588,8 @@
     "base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true
     },
     "baseline-browser-mapping": {
       "version": "2.9.11",
@@ -10770,27 +10597,12 @@
       "integrity": "sha512-Sg0xJUNDU1sJNGdfGWhVHX0kkZ+HWcvmVymJbj6NSgZZmW/8S9Y2HQ5euytnIgakgxN6papOAWiwDo1ctFDcoQ==",
       "dev": true
     },
-    "better-sqlite3": {
-      "version": "12.5.0",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.5.0.tgz",
-      "integrity": "sha512-WwCZ/5Diz7rsF29o27o0Gcc1Du+l7Zsv7SYtVPG0X3G/uUI1LqdxrQI7c9Hs2FWpqXXERjW9hp6g3/tH7DlVKg==",
-      "requires": {
-        "bindings": "^1.5.0",
-        "prebuild-install": "^7.1.1"
-      }
-    },
-    "bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "requires": {
-        "file-uri-to-path": "1.0.0"
-      }
-    },
     "bl": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
       "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "peer": true,
       "requires": {
         "buffer": "^5.5.0",
         "inherits": "^2.0.4",
@@ -10845,6 +10657,7 @@
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
       "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
       "requires": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
@@ -11639,6 +11452,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
       "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "dev": true,
       "requires": {
         "mimic-response": "^3.1.0"
       },
@@ -11646,14 +11460,10 @@
         "mimic-response": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-          "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ=="
+          "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+          "dev": true
         }
       }
-    },
-    "deep-extend": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
     },
     "defer-to-connect": {
       "version": "2.0.1",
@@ -11702,7 +11512,8 @@
     "detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
-      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true
     },
     "detect-node": {
       "version": "2.1.0",
@@ -12040,6 +11851,7 @@
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
       "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
       "requires": {
         "once": "^1.4.0"
       }
@@ -12140,11 +11952,6 @@
       "dev": true,
       "optional": true
     },
-    "expand-template": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
-      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="
-    },
     "extract-zip": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
@@ -12184,11 +11991,6 @@
       "requires": {
         "pend": "~1.2.0"
       }
-    },
-    "file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
     },
     "filelist": {
       "version": "1.0.4",
@@ -12242,7 +12044,9 @@
     "fs-constants": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "dev": true,
+      "peer": true
     },
     "fs-extra": {
       "version": "8.1.0",
@@ -12321,11 +12125,6 @@
       "requires": {
         "pump": "^3.0.0"
       }
-    },
-    "github-from-package": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw=="
     },
     "glob": {
       "version": "7.2.3",
@@ -12570,7 +12369,8 @@
     "ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true
     },
     "inflight": {
       "version": "1.0.6",
@@ -12585,12 +12385,8 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-    },
-    "ini": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
     },
     "internmap": {
       "version": "2.0.3",
@@ -12985,7 +12781,8 @@
     "minimist": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true
     },
     "minipass": {
       "version": "7.1.2",
@@ -12998,11 +12795,6 @@
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
       "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
       "dev": true
-    },
-    "mkdirp-classic": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
     },
     "mlly": {
       "version": "1.8.2",
@@ -13026,11 +12818,6 @@
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
       "dev": true
-    },
-    "napi-build-utils": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
-      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA=="
     },
     "node-addon-api": {
       "version": "1.7.2",
@@ -13069,6 +12856,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -13242,35 +13030,6 @@
         "source-map-js": "^1.2.1"
       }
     },
-    "prebuild-install": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
-      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
-      "requires": {
-        "detect-libc": "^2.0.0",
-        "expand-template": "^2.0.3",
-        "github-from-package": "0.0.0",
-        "minimist": "^1.2.3",
-        "mkdirp-classic": "^0.5.3",
-        "napi-build-utils": "^2.0.0",
-        "node-abi": "^3.3.0",
-        "pump": "^3.0.0",
-        "rc": "^1.2.7",
-        "simple-get": "^4.0.0",
-        "tar-fs": "^2.0.0",
-        "tunnel-agent": "^0.6.0"
-      },
-      "dependencies": {
-        "node-abi": {
-          "version": "3.85.0",
-          "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.85.0.tgz",
-          "integrity": "sha512-zsFhmbkAzwhTft6nd3VxcG0cvJsT70rL+BIGHWVq5fi6MwGrHwzqKaxXE+Hl2GmnGItnDKPPkO5/LQqjVkIdFg==",
-          "requires": {
-            "semver": "^7.3.5"
-          }
-        }
-      }
-    },
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -13298,6 +13057,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
       "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+      "dev": true,
       "requires": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -13384,17 +13144,6 @@
       "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
       "dev": true
     },
-    "rc": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-      "requires": {
-        "deep-extend": "^0.6.0",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
-      }
-    },
     "react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
@@ -13446,6 +13195,8 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "peer": true,
       "requires": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -13576,7 +13327,9 @@
     "safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "peer": true
     },
     "safer-buffer": {
       "version": "2.1.2",
@@ -13609,7 +13362,8 @@
     "semver": {
       "version": "7.7.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "dev": true
     },
     "semver-compare": {
       "version": "1.0.0",
@@ -13689,21 +13443,6 @@
       "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
       "dev": true
     },
-    "simple-concat": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="
-    },
-    "simple-get": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
-      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
-      "requires": {
-        "decompress-response": "^6.0.0",
-        "once": "^1.3.1",
-        "simple-concat": "^1.0.0"
-      }
-    },
     "simple-update-notifier": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
@@ -13767,6 +13506,11 @@
       "dev": true,
       "optional": true
     },
+    "sql.js": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/sql.js/-/sql.js-1.14.1.tgz",
+      "integrity": "sha512-gcj8zBWU5cFsi9WUP+4bFNXAyF1iRpA3LLyS/DP5xlrNzGmPIizUeBggKa8DbDwdqaKwUcTEnChtd2grWo/x/A=="
+    },
     "stat-mode": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-1.0.0.tgz",
@@ -13777,6 +13521,8 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "peer": true,
       "requires": {
         "safe-buffer": "~5.2.0"
       }
@@ -13818,11 +13564,6 @@
       "requires": {
         "ansi-regex": "^5.0.1"
       }
-    },
-    "strip-json-comments": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="
     },
     "stylis": {
       "version": "4.3.6",
@@ -13916,28 +13657,12 @@
         }
       }
     },
-    "tar-fs": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
-      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
-      "requires": {
-        "chownr": "^1.1.1",
-        "mkdirp-classic": "^0.5.2",
-        "pump": "^3.0.0",
-        "tar-stream": "^2.1.4"
-      },
-      "dependencies": {
-        "chownr": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-          "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
-        }
-      }
-    },
     "tar-stream": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
       "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "dev": true,
+      "peer": true,
       "requires": {
         "bl": "^4.0.3",
         "end-of-stream": "^1.4.1",
@@ -14052,14 +13777,6 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true
     },
-    "tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
-      "requires": {
-        "safe-buffer": "^5.0.1"
-      }
-    },
     "type-fest": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
@@ -14123,7 +13840,9 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "peer": true
     },
     "uuid": {
       "version": "9.0.1",
@@ -14254,7 +13973,8 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true
     },
     "ws": {
       "version": "8.19.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@xterm/addon-unicode11": "^0.8.0",
     "@xterm/addon-web-links": "^0.11.0",
     "@xterm/xterm": "^5.5.0",
-    "better-sqlite3": "^12.5.0",
+    "sql.js": "^1.12.0",
     "dompurify": "^3.3.3",
     "highlight.js": "^11.11.1",
     "i18next": "^25.8.18",
@@ -45,7 +45,7 @@
     "@lydell/node-pty": "^1.1.0"
   },
   "devDependencies": {
-    "@types/better-sqlite3": "^7.6.13",
+    "@types/sql.js": "^1.4.9",
     "@types/node": "^20.0.0",
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",

--- a/src/components/ClaudeAgentPanel.tsx
+++ b/src/components/ClaudeAgentPanel.tsx
@@ -129,7 +129,6 @@ export function ClaudeAgentPanel({ sessionId, cwd, isActive, workspaceId }: Read
   const [permissionMode, setPermissionMode] = useState<string>('bypassPermissions')
   const [currentModel, setCurrentModel] = useState<string>('')
   const [effortLevel, setEffortLevel] = useState<string>('medium')
-  const [enable1MContext, setEnable1MContext] = useState(false)
   const [claudeUsage, setClaudeUsage] = useState(workspaceStore.claudeUsage)
   const [availableModels, setAvailableModels] = useState<ModelInfo[]>([])
   const [pendingPermission, setPendingPermission] = useState<PendingPermission | null>(null)
@@ -749,7 +748,7 @@ export function ClaudeAgentPanel({ sessionId, cwd, isActive, workspaceId }: Read
         historyLoadedRef.current = true
         window.electronAPI.claude.resumeSession(sessionId, savedSdkSessionId, cwd, savedModel)
       } else {
-        dlog(`${stag} FRESH startSession`)
+        dlog(`${stag} FRESH startSession model=${effectiveModel || 'SDK-default'}`)
         window.electronAPI.claude.startSession(sessionId, { cwd, permissionMode, model: effectiveModel, effort: effectiveEffort as 'low' | 'medium' | 'high' | 'max' })
       }
     }
@@ -776,7 +775,18 @@ export function ClaudeAgentPanel({ sessionId, cwd, isActive, workspaceId }: Read
       window.electronAPI.claude.getSupportedModels(sessionId).then((models: ModelInfo[]) => {
         console.log('[getSupportedModels] raw response:', JSON.stringify(models, null, 2))
         if (models && models.length > 0) {
-          setAvailableModels(models)
+          // Inject [1m] variants for models that support 1M context
+          const withExtras = [...models]
+          const opusEntry = models.find(m => m.value === 'claude-opus-4-6')
+          if (opusEntry && !models.some(m => m.value === 'claude-opus-4-6[1m]')) {
+            const idx = models.indexOf(opusEntry)
+            withExtras.splice(idx + 1, 0, {
+              value: 'claude-opus-4-6[1m]',
+              displayName: 'Claude Opus 4.6 [1M]',
+              description: 'Opus 4.6 with 1M token context window',
+            })
+          }
+          setAvailableModels(withExtras)
         }
       }).catch(() => {})
       window.electronAPI.claude.getAccountInfo(sessionId).then(info => {
@@ -811,6 +821,14 @@ export function ClaudeAgentPanel({ sessionId, cwd, isActive, workspaceId }: Read
     return workspaceStore.subscribe(() => {
       const u = workspaceStore.claudeUsage
       if (u) setClaudeUsage(u)
+    })
+  }, [])
+
+  // Update usage from SDK rate_limit_event (no polling needed, fires on every query)
+  useEffect(() => {
+    return window.electronAPI.claude.onUsageUpdate((info) => {
+      window.electronAPI.debug.log(`[usage:rate_limit_event] type=${info.rateLimitType} util=${info.utilization} resetsAt=${info.resetsAt ?? 'none'}`)
+      workspaceStore.applyRateLimitEvent(info)
     })
   }, [])
 
@@ -1161,6 +1179,11 @@ export function ClaudeAgentPanel({ sessionId, cwd, isActive, workspaceId }: Read
     if (e.key === 'ArrowUp' && !e.shiftKey && !e.nativeEvent.isComposing) {
       const history = inputHistoryRef.current
       if (history.length === 0) return
+      // In multi-line input, only navigate history when cursor is on the first line
+      const ta = e.currentTarget as HTMLTextAreaElement
+      const firstNewline = ta.value.indexOf('\n')
+      const isOnFirstLine = firstNewline === -1 || ta.selectionStart <= firstNewline
+      if (!isOnFirstLine) return
       e.preventDefault()
       if (inputHistoryIndexRef.current === -1) {
         inputDraftRef.current = inputValueRef.current
@@ -1173,6 +1196,11 @@ export function ClaudeAgentPanel({ sessionId, cwd, isActive, workspaceId }: Read
     }
     if (e.key === 'ArrowDown' && !e.shiftKey && !e.nativeEvent.isComposing) {
       if (inputHistoryIndexRef.current === -1) return
+      // In multi-line input, only navigate history when cursor is on the last line
+      const ta = e.currentTarget as HTMLTextAreaElement
+      const lastNewline = ta.value.lastIndexOf('\n')
+      const isOnLastLine = lastNewline === -1 || ta.selectionStart > lastNewline
+      if (!isOnLastLine) return
       e.preventDefault()
       const history = inputHistoryRef.current
       if (inputHistoryIndexRef.current < history.length - 1) {
@@ -1204,13 +1232,6 @@ export function ClaudeAgentPanel({ sessionId, cwd, isActive, workspaceId }: Read
     setEffortLevel(next)
     await window.electronAPI.claude.setEffort(sessionId, next)
   }, [sessionId])
-
-  const handle1MContextToggle = useCallback(async () => {
-    const next = !enable1MContext
-    setEnable1MContext(next)
-    settingsStore.setEnable1MContext(next)
-    await window.electronAPI.claude.set1MContext(sessionId, next)
-  }, [sessionId, enable1MContext])
 
   const showDontAskAgain = (pendingPermission?.suggestions?.length ?? 0) > 0
     || pendingPermission?.toolName === 'ExitPlanMode'
@@ -2061,8 +2082,7 @@ export function ClaudeAgentPanel({ sessionId, cwd, isActive, workspaceId }: Read
               {item.result && (() => {
                 const raw = typeof item.result === 'string' ? item.result : String(item.result)
                 const { content: outText, reminders, errors } = splitSystemReminders(raw)
-                // Hide output by default for read-only tools (Read, Glob, Grep, LS, NotebookRead)
-                const isReadOnlyTool = ['Read', 'Glob', 'Grep', 'LS', 'NotebookRead'].includes(item.toolName)
+                // All tool outputs collapsed by default — click to expand
                 const isOutExpanded = expandedTools.has(outBlockId)
                 return (
                   <>
@@ -2072,7 +2092,7 @@ export function ClaudeAgentPanel({ sessionId, cwd, isActive, workspaceId }: Read
                         <span className="claude-tool-row-content">{err}</span>
                       </div>
                     ))}
-                    {outText && isReadOnlyTool && (
+                    {outText && (
                       <div
                         className="claude-tool-row"
                         onClick={() => toggleTool(outBlockId)}
@@ -2084,20 +2104,15 @@ export function ClaudeAgentPanel({ sessionId, cwd, isActive, workspaceId }: Read
                             : <span className="claude-tool-collapsed-hint">{outText.split('\n').length} lines</span>
                           }
                         </span>
+                        {isOutExpanded && (
+                          <span
+                            className={`claude-tool-row-copy ${copiedId === outBlockId ? 'copied' : ''}`}
+                            onClick={(e) => { e.stopPropagation(); handleCopyBlock(outText, outBlockId) }}
+                          >
+                            {copiedId === outBlockId ? '✓' : '⧉'}
+                          </span>
+                        )}
                         <span className={`claude-tool-chevron ${isOutExpanded ? 'expanded' : ''}`}>&#9654;</span>
-                      </div>
-                    )}
-                    {outText && !isReadOnlyTool && (
-                      <div
-                        className="claude-tool-row"
-                        onClick={() => handleCopyBlock(outText, outBlockId)}
-                        title={t('claude.clickToCopy')}
-                      >
-                        <span className="claude-tool-row-label">{t('claude.out')}</span>
-                        <span className="claude-tool-row-content"><LinkedText text={outText} /></span>
-                        <span className={`claude-tool-row-copy ${copiedId === outBlockId ? 'copied' : ''}`}>
-                          {copiedId === outBlockId ? '✓' : '⧉'}
-                        </span>
                       </div>
                     )}
                     {reminders.length > 0 && (
@@ -2905,9 +2920,11 @@ export function ClaudeAgentPanel({ sessionId, cwd, isActive, workspaceId }: Read
             if (!sessionMeta || sessionMeta.contextWindow <= 0) return null
             const ctxTokens = sessionMeta.contextTokens || (sessionMeta.inputTokens + sessionMeta.outputTokens)
             const pct = Math.round((ctxTokens / sessionMeta.contextWindow) * 100)
+            const ctxColor = pct <= 50 ? '#98c379' : pct < 80 ? '#e5c07b' : '#e06c75'
+            const is1M = sessionMeta.contextWindow >= 1000000
             return (
-              <span key="contextPct" className="claude-statusline-item" title={`context: ${ctxTokens.toLocaleString()} / ${sessionMeta.contextWindow.toLocaleString()} tokens\ntotal: ${(sessionMeta.inputTokens + sessionMeta.outputTokens).toLocaleString()} tok`}>
-                ctx {pct}%
+              <span key="contextPct" className="claude-statusline-item" style={{ color: ctxColor }} title={`context: ${ctxTokens.toLocaleString()} / ${sessionMeta.contextWindow.toLocaleString()} tokens\ntotal: ${(sessionMeta.inputTokens + sessionMeta.outputTokens).toLocaleString()} tok`}>
+                ctx {pct}%{is1M && <span style={{ color: '#6cf', marginLeft: 3, fontWeight: 600 }}>1M</span>}
               </span>
             )
           },
@@ -2918,11 +2935,31 @@ export function ClaudeAgentPanel({ sessionId, cwd, isActive, workspaceId }: Read
             const ws = workspaceId ? workspaceStore.getState().workspaces.find(w => w.id === workspaceId) : null
             return ws ? <span key="workspace" className="claude-statusline-item">{ws.alias || ws.name}</span> : null
           },
-          usage5h: () => claudeUsage?.fiveHour == null ? null : (
-            <span key="usage5h" className={`claude-statusline-item${claudeUsage.fiveHour > 80 ? ' claude-usage-high' : claudeUsage.fiveHour > 50 ? ' claude-usage-mid' : ''}`}>
-              5h:{Math.round(claudeUsage.fiveHour)}%
-            </span>
-          ),
+          usage5h: () => {
+            if (!claudeUsage) return null
+            if (claudeUsage.fiveHourStale) return (
+              <span key="usage5h" className="claude-statusline-item claude-usage-stale">5h:--%</span>
+            )
+            if (claudeUsage.fiveHour == null) return null
+            const pacing = workspaceStore.getUsagePacing()
+            const paceIcon = pacing ? (pacing.onPace ? '▼' : '▲') : ''
+            const paceClass = pacing && !pacing.onPace ? ' claude-usage-overpace' : ''
+            let title = `5h utilization: ${claudeUsage.fiveHour.toFixed(1)}%`
+            if (pacing) {
+              title += `\nTime elapsed: ${pacing.timeElapsedPct.toFixed(0)}%`
+              title += pacing.onPace ? '\nOn pace ── usage within window budget' : '\nOver pace ── burning faster than replenish'
+              if (pacing.estimatedMinutesToLimit != null) {
+                const h = Math.floor(pacing.estimatedMinutesToLimit / 60)
+                const m = pacing.estimatedMinutesToLimit % 60
+                title += `\nEstimated limit in: ${h > 0 ? `${h}h${m}m` : `${m}m`}`
+              }
+            }
+            return (
+              <span key="usage5h" title={title} className={`claude-statusline-item${claudeUsage.fiveHour > 80 ? ' claude-usage-high' : claudeUsage.fiveHour > 50 ? ' claude-usage-mid' : ' claude-usage-low'}${paceClass}`}>
+                5h:{Math.round(claudeUsage.fiveHour)}%{paceIcon}
+              </span>
+            )
+          },
           usage5hReset: () => {
             if (!claudeUsage?.fiveHourReset) return null
             return <span key="usage5hReset" className="claude-statusline-item">↻{fmtRemaining(new Date(claudeUsage.fiveHourReset))}</span>
@@ -2953,8 +2990,8 @@ export function ClaudeAgentPanel({ sessionId, cwd, isActive, workspaceId }: Read
           for (const item of items) {
             let node = renderers[item.id]?.()
             if (!node) continue
-            // Apply color directly on the element via cloneElement to override class-based colors
-            if (item.color && isValidElement(node)) {
+            // Apply color from config, but don't override dynamic colors already set on the element
+            if (item.color && isValidElement(node) && !node.props.style?.color) {
               node = cloneElement(node, { style: { ...(node.props.style || {}), color: item.color } })
             }
             nodes.push(node)

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -312,18 +312,6 @@ export function SettingsPanel({ onClose }: SettingsPanelProps) {
               <p className="settings-hint">{t('settings.allowBypassPermissionsHint')}</p>
             </div>
 
-            <div className="settings-group checkbox-group">
-              <label>
-                <input
-                  type="checkbox"
-                  checked={settings.enable1MContext !== false}
-                  onChange={e => settingsStore.setEnable1MContext(e.target.checked)}
-                />
-                {t('settings.enable1MContext')}
-              </label>
-              <p className="settings-hint">{t('settings.enable1MContextHint')}</p>
-            </div>
-
             <div className="settings-group">
               <label>{t('settings.defaultModel')}</label>
               <input

--- a/src/components/ThumbnailBar.tsx
+++ b/src/components/ThumbnailBar.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useCallback } from 'react'
+import { useState, useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { TerminalInstance } from '../types'
 import { TerminalThumbnail } from './TerminalThumbnail'
@@ -10,6 +10,8 @@ interface ThumbnailBarProps {
   onFocus: (id: string) => void
   onAddTerminal?: () => void
   onAddClaudeAgent?: () => void
+  onAddClaudeAgent1M?: () => void
+  onAddTerminalWithCommand?: (command: string) => void
   onReorder?: (orderedIds: string[]) => void
   showAddButton: boolean
   height?: number
@@ -23,6 +25,8 @@ export function ThumbnailBar({
   onFocus,
   onAddTerminal,
   onAddClaudeAgent,
+  onAddClaudeAgent1M,
+  onAddTerminalWithCommand,
   onReorder,
   showAddButton,
   height,
@@ -41,20 +45,6 @@ export function ThumbnailBar({
   const [draggedId, setDraggedId] = useState<string | null>(null)
   const [dropTargetId, setDropTargetId] = useState<string | null>(null)
   const [dropPosition, setDropPosition] = useState<'before' | 'after'>('before')
-  const [showAddMenu, setShowAddMenu] = useState(false)
-  const addMenuRef = useRef<HTMLDivElement>(null)
-
-  // Close menu on outside click
-  useEffect(() => {
-    if (!showAddMenu) return
-    const handleClick = (e: MouseEvent) => {
-      if (addMenuRef.current && !addMenuRef.current.contains(e.target as Node)) {
-        setShowAddMenu(false)
-      }
-    }
-    document.addEventListener('mousedown', handleClick)
-    return () => document.removeEventListener('mousedown', handleClick)
-  }, [showAddMenu])
 
   const handleDragStart = useCallback((e: React.DragEvent, id: string) => {
     setDraggedId(id)
@@ -143,36 +133,25 @@ export function ThumbnailBar({
       <div className="thumbnail-bar-header">
         <span>{label}</span>
         <div className="thumbnail-bar-actions">
+          {onAddClaudeAgent && (
+            <button className="thumbnail-action-btn thumbnail-action-claude" onClick={onAddClaudeAgent} title="Claude Code (SDK Agent)">
+              ✦ Claude
+            </button>
+          )}
+          {onAddClaudeAgent1M && (
+            <button className="thumbnail-action-btn thumbnail-action-claude1m" onClick={onAddClaudeAgent1M} title="Claude Code (SDK Agent + 1M context)">
+              ✦ Claude 1M
+            </button>
+          )}
+          {onAddTerminalWithCommand && (
+            <button className="thumbnail-action-btn thumbnail-action-opus" onClick={() => onAddTerminalWithCommand('claude --model=opus[1m] --dangerously-skip-permissions')} title="Terminal: claude --model=opus[1m] --dangerously-skip-permissions">
+              Super Opus 1M
+            </button>
+          )}
           {onAddTerminal && (
-            <div className="thumbnail-add-wrapper" ref={addMenuRef}>
-              <button
-                className="thumbnail-add-btn"
-                onClick={() => setShowAddMenu(prev => !prev)}
-                title={t('terminal.addTerminalOrAgent')}
-              >
-                +
-              </button>
-              {showAddMenu && (
-                <div className="thumbnail-add-menu">
-                  <div
-                    className="thumbnail-add-menu-item"
-                    onClick={() => { onAddTerminal(); setShowAddMenu(false) }}
-                  >
-                    <span className="thumbnail-add-menu-icon">⌘</span>
-                    {t('terminal.terminalLabel')}
-                  </div>
-                  {onAddClaudeAgent && (
-                    <div
-                      className="thumbnail-add-menu-item"
-                      onClick={() => { onAddClaudeAgent(); setShowAddMenu(false) }}
-                    >
-                      <span className="thumbnail-add-menu-icon" style={{ color: '#d97706' }}>✦</span>
-                      Claude Code
-                    </div>
-                  )}
-                </div>
-              )}
-            </div>
+            <button className="thumbnail-action-btn thumbnail-action-terminal" onClick={onAddTerminal} title="Terminal: claude (wait for enter)">
+              ⌘ Terminal
+            </button>
           )}
           {onCollapse && (
             <button className="thumbnail-collapse-btn" onClick={onCollapse} title={t('terminal.collapsePanel')}>

--- a/src/components/WorkspaceView.tsx
+++ b/src/components/WorkspaceView.tsx
@@ -266,10 +266,35 @@ export function WorkspaceView({ workspace, terminals, focusedTerminalId, isActiv
 
   const handleAddClaudeAgent = useCallback(() => {
     const agentTerminal = workspaceStore.addTerminal(workspace.id, 'claude-code' as AgentPresetId)
-    // Claude Agent SDK session will be started by ClaudeAgentPanel on mount
     workspaceStore.setFocusedTerminal(agentTerminal.id)
     workspaceStore.save()
   }, [workspace.id])
+
+  const handleAddClaudeAgent1M = useCallback(() => {
+    const agentTerminal = workspaceStore.addTerminal(workspace.id, 'claude-code' as AgentPresetId, { model: 'claude-opus-4-6[1m]' })
+    workspaceStore.setFocusedTerminal(agentTerminal.id)
+    workspaceStore.save()
+  }, [workspace.id])
+
+  const handleAddTerminalWithCommand = useCallback(async (command: string) => {
+    const terminal = workspaceStore.addTerminal(workspace.id)
+    const shell = await getShellFromSettings()
+    const settings = settingsStore.getSettings()
+    const customEnv = mergeEnvVars(settings.globalEnvVars, workspace.envVars)
+    window.electronAPI.pty.create({
+      id: terminal.id,
+      cwd: workspace.folderPath,
+      type: 'terminal',
+      shell,
+      customEnv
+    })
+    workspaceStore.setFocusedTerminal(terminal.id)
+    workspaceStore.save()
+    // Type command after PTY is ready (don't press enter — let user confirm)
+    setTimeout(() => {
+      window.electronAPI.pty.write(terminal.id, command)
+    }, 500)
+  }, [workspace.id, workspace.folderPath, workspace.envVars])
 
   const handleCloseTerminal = useCallback((id: string) => {
     const terminal = terminals.find(t => t.id === id)
@@ -408,6 +433,8 @@ export function WorkspaceView({ workspace, terminals, focusedTerminalId, isActiv
         onFocus={handleFocus}
         onAddTerminal={handleAddTerminal}
         onAddClaudeAgent={handleAddClaudeAgent}
+        onAddClaudeAgent1M={handleAddClaudeAgent1M}
+        onAddTerminalWithCommand={handleAddTerminalWithCommand}
         onReorder={handleReorderTerminals}
         showAddButton={true}
         height={thumbnailSettings.height}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -37,8 +37,6 @@
     "autoRunAgentCommandHint": "Automatically execute the agent command (e.g., `claude`) when creating an Agent Terminal.",
     "allowBypassPermissions": "Allow bypass permissions without confirmation",
     "allowBypassPermissionsHint": "When enabled, switching to bypassPermissions mode in Claude Agent Panel will not show a confirmation dialog. Use with caution.",
-    "enable1MContext": "Enable 1M token context window",
-    "enable1MContextHint": "Use the extended 1M token context window for supported models (Opus 4.6, Sonnet 4.6). Disable to use the default 200K context.",
     "defaultModel": "Default Model",
     "defaultModelPlaceholder": "e.g., claude-sonnet-4-5-20250514",
     "defaultModelHint": "Model ID used for new Agent sessions. Leave empty to use SDK default.",

--- a/src/locales/zh-TW.json
+++ b/src/locales/zh-TW.json
@@ -37,8 +37,6 @@
     "autoRunAgentCommandHint": "建立 Agent 終端時自動執行 Agent 指令（例如 `claude`）。",
     "allowBypassPermissions": "允許跳過權限確認",
     "allowBypassPermissionsHint": "啟用後，在 Claude Agent 面板中切換至 bypassPermissions 模式時不會顯示確認對話框。請謹慎使用。",
-    "enable1MContext": "啟用 1M token 上下文視窗",
-    "enable1MContextHint": "對支援的模型（Opus 4.6、Sonnet 4.6）使用擴展的 1M token 上下文視窗。停用則使用預設的 200K 上下文。",
     "defaultModel": "預設模型",
     "defaultModelPlaceholder": "例如 claude-sonnet-4-5-20250514",
     "defaultModelHint": "新 Agent 對話使用的模型 ID。留空則使用 SDK 預設。",

--- a/src/stores/settings-store.ts
+++ b/src/stores/settings-store.ts
@@ -26,7 +26,6 @@ const defaultSettings: AppSettings = {
   defaultTerminalCount: 1,
   createDefaultAgentTerminal: true,
   allowBypassPermissions: true,
-  enable1MContext: true
 }
 
 class SettingsStore {
@@ -182,12 +181,6 @@ class SettingsStore {
 
   setAllowBypassPermissions(allow: boolean): void {
     this.settings = { ...this.settings, allowBypassPermissions: allow }
-    this.notify()
-    this.save()
-  }
-
-  setEnable1MContext(enable: boolean): void {
-    this.settings = { ...this.settings, enable1MContext: enable }
     this.notify()
     this.save()
   }

--- a/src/stores/workspace-store.ts
+++ b/src/stores/workspace-store.ts
@@ -19,49 +19,183 @@ class WorkspaceStore {
   private listeners: Set<Listener> = new Set()
 
   // Global Claude usage (shared across all panels)
-  // Adaptive polling: backs off on rate limits, pauses when hidden, refreshes on focus
-  private _claudeUsage: { fiveHour: number | null; sevenDay: number | null; fiveHourReset: string | null; sevenDayReset: string | null } | null = null
+  // Primary source: SDK rate_limit_event (fires on every query, persisted to localStorage)
+  // Fallback: adaptive polling (cold-start / no session history), backs off on rate limits
+  private _claudeUsage: { fiveHour: number | null; sevenDay: number | null; fiveHourReset: string | null; sevenDayReset: string | null; fiveHourStale?: boolean; sevenDayStale?: boolean /* unused — 7d changes slowly, always show last known value */ } | null = null
   private _usageTimer: ReturnType<typeof setTimeout> | null = null
   private _usagePollingStarted = false
   private _usageInflight = false
-  private _usageBaseInterval = 120 * 1000            // 2 min normal (API has strict rate limits)
-  private _usageCurrentInterval = 120 * 1000
-  private _usageMaxInterval = 30 * 60 * 1000       // 30 min max backoff
-  private _usageMinInterval = 60 * 1000             // 1 min min (after activity)
-  private _usageRateLimitMin = 120 * 1000           // 2 min min when rate limited
+  private _usageRateLimited = false                  // true while in rate-limit backoff — blocks refreshUsageNow
+  private _usageRateLimitStreak = 0                 // consecutive 429s — drives cumulative backoff
+  private _usageBaseInterval = 10 * 60 * 1000       // 10 min idle (SDK events are primary source)
+  private _usageCurrentInterval = 10 * 60 * 1000
+  private _usageMaxInterval = 10 * 60 * 1000        // 10 min max backoff
+  private _usageMinInterval = 60 * 1000              // 1 min min (after activity)
   private _visibilityHandler: (() => void) | null = null
+  // One-shot timer: starts on first failure, cancelled on success, fires once to mark stale
+  private _fiveHourStaleTimer: ReturnType<typeof setTimeout> | null = null
+  private static readonly _FIVE_HOUR_STALE_MS = 10 * 60 * 1000  // 10 min without data → show --%
+  private static readonly _USAGE_CACHE_KEY = 'bat_claude_usage_cache'
 
   get claudeUsage() { return this._claudeUsage }
+
+  /** Pacing analysis for 5h window: compare utilization vs time elapsed percentage.
+   *  Returns null if data is insufficient. */
+  getUsagePacing(): { onPace: boolean; timeElapsedPct: number; estimatedMinutesToLimit: number | null } | null {
+    const u = this._claudeUsage
+    if (!u || u.fiveHour == null || !u.fiveHourReset) return null
+
+    const now = Date.now()
+    const resetMs = new Date(u.fiveHourReset).getTime()
+    const periodMs = 5 * 3600_000
+    const remainingMs = Math.max(0, resetMs - now)
+    const elapsedMs = periodMs - remainingMs
+    if (elapsedMs <= 0) return null
+
+    const timeElapsedPct = (elapsedMs / periodMs) * 100
+    const onPace = u.fiveHour <= timeElapsedPct
+
+    // Predict time to 100% based on current burn rate, capped to remaining window
+    let estimatedMinutesToLimit: number | null = null
+    if (u.fiveHour > 0) {
+      const ratePerMs = u.fiveHour / elapsedMs
+      const remaining = 100 - u.fiveHour
+      if (ratePerMs > 0) {
+        const remainingMin = Math.round(remainingMs / 60_000)
+        estimatedMinutesToLimit = Math.min(Math.round(remaining / ratePerMs / 60_000), remainingMin)
+      }
+    }
+
+    return { onPace, timeElapsedPct, estimatedMinutesToLimit }
+  }
+
+  /** Persist current usage to localStorage so it survives app restarts */
+  private _persistUsage() {
+    if (!this._claudeUsage) return
+    try {
+      const { fiveHourStale: _, ...data } = this._claudeUsage
+      localStorage.setItem(WorkspaceStore._USAGE_CACHE_KEY, JSON.stringify({
+        ...data,
+        savedAt: new Date().toISOString(),
+      }))
+    } catch { /* quota exceeded or unavailable — non-fatal */ }
+  }
+
+  /** Restore persisted usage on startup; clears components whose resetsAt has already passed */
+  private _loadPersistedUsage() {
+    try {
+      const raw = localStorage.getItem(WorkspaceStore._USAGE_CACHE_KEY)
+      if (!raw) return
+      const cached = JSON.parse(raw) as {
+        fiveHour: number | null; sevenDay: number | null
+        fiveHourReset: string | null; sevenDayReset: string | null
+        savedAt?: string
+      }
+      const now = Date.now()
+      const fiveResetMs = cached.fiveHourReset ? new Date(cached.fiveHourReset).getTime() : null
+      const sevenResetMs = cached.sevenDayReset ? new Date(cached.sevenDayReset).getTime() : null
+      // If the reset time has already passed, the limit has rolled over — clear that slot
+      const fiveExpired = fiveResetMs !== null && now > fiveResetMs
+      const sevenExpired = sevenResetMs !== null && now > sevenResetMs
+      // Load as not-stale — SDK event or successful poll will confirm freshness.
+      // The stale timer started by the first failed poll will mark stale if no data arrives.
+      this._claudeUsage = {
+        fiveHour:      fiveExpired  ? null : cached.fiveHour,
+        fiveHourReset: fiveExpired  ? null : cached.fiveHourReset,
+        sevenDay:      sevenExpired ? null : cached.sevenDay,
+        sevenDayReset: sevenExpired ? null : cached.sevenDayReset,
+        fiveHourStale: false,
+      }
+      this.notify()
+    } catch { /* corrupt cache — ignore, polling will populate fresh data */ }
+  }
+
+  private _clearFiveHourStaleTimer() {
+    if (this._fiveHourStaleTimer) {
+      clearTimeout(this._fiveHourStaleTimer)
+      this._fiveHourStaleTimer = null
+    }
+  }
+
+  /** Start the stale timer only if not already running and not already stale.
+   *  If the current poll interval already exceeds the stale threshold (e.g. 30min backoff or
+   *  server-directed rate limit), mark stale immediately — waiting 10min would show stale data
+   *  as fresh during a window where we know no poll is coming. */
+  private _startFiveHourStaleTimerIfNeeded() {
+    if (this._fiveHourStaleTimer !== null) return   // timer already running — don't reset
+    if (this._claudeUsage?.fiveHourStale) return    // already stale — nothing to do
+    if (this._usageCurrentInterval > WorkspaceStore._FIVE_HOUR_STALE_MS) {
+      // Next poll is further away than the stale window — no point waiting for the timer
+      const prev = this._claudeUsage ?? { fiveHour: null, sevenDay: null, fiveHourReset: null, sevenDayReset: null }
+      this._claudeUsage = { ...prev, fiveHourStale: true }
+      window.electronAPI.debug.log(`[usage:poll] stale immediately — next poll in ${this._usageCurrentInterval / 60000}min`)
+      this.notify()
+      return
+    }
+    this._fiveHourStaleTimer = setTimeout(() => {
+      this._fiveHourStaleTimer = null
+      const prev = this._claudeUsage ?? { fiveHour: null, sevenDay: null, fiveHourReset: null, sevenDayReset: null }
+      this._claudeUsage = { ...prev, fiveHourStale: true }
+      window.electronAPI.debug.log(`[usage:poll] stale — no data for ${WorkspaceStore._FIVE_HOUR_STALE_MS / 60000} min`)
+      this.notify()
+    }, WorkspaceStore._FIVE_HOUR_STALE_MS)
+  }
 
   private async _fetchUsage() {
     if (this._usageInflight) return
     this._usageInflight = true
     try {
       const u = await window.electronAPI.claude.getUsage()
-      if (!u) return
+      if (!u) {
+        // null = both auth methods returned non-OK (e.g. 401/403/5xx) — counts as a failure
+        this._startFiveHourStaleTimerIfNeeded()
+        return
+      }
 
       // Handle rate-limit response from main process
       // Use server's retryAfterSec directly — do not double existing interval,
       // since OAuth always rate-limits on Windows and exponential backoff causes 1.5h+ staleness
       if ('rateLimited' in u && (u as any).rateLimited) {
-        const retryAfterMs = ((u as any).retryAfterSec || 60) * 1000
-        this._usageCurrentInterval = Math.min(retryAfterMs, this._usageMaxInterval)
+        this._usageRateLimitStreak++
+        // cumulative backoff: 120s → 240s → 480s → 600s (10 min cap), ignores server retry-after
+        const backoffMs = Math.min(120_000 * Math.pow(2, this._usageRateLimitStreak - 1), this._usageMaxInterval)
+        this._usageCurrentInterval = backoffMs
+        this._usageRateLimited = true
+        window.electronAPI.debug.log(`[usage:poll] rate-limited (streak=${this._usageRateLimitStreak}), retry in ${Math.round(backoffMs / 1000)}s`)
+        this._startFiveHourStaleTimerIfNeeded()
         return
       }
 
-      // Success — reset to base interval
+      // Success — cancel stale timer, clear stale flag, reset poll interval
+      // Merge with existing state: prefer poll values, fall back to prior SDK event values for null fields
+      this._clearFiveHourStaleTimer()
+      this._usageRateLimited = false
+      this._usageRateLimitStreak = 0
       this._usageCurrentInterval = this._usageBaseInterval
-      this._claudeUsage = u
+      const prev = this._claudeUsage ?? { fiveHour: null, sevenDay: null, fiveHourReset: null, sevenDayReset: null }
+      const polled = u as any
+      window.electronAPI.debug.log(`[usage:poll] OK 5h=${polled.fiveHour} 7d=${polled.sevenDay} 5hReset=${polled.fiveHourReset} 7dReset=${polled.sevenDayReset}`)
+      this._claudeUsage = {
+        fiveHour:      polled.fiveHour      ?? prev.fiveHour,
+        sevenDay:      polled.sevenDay      ?? prev.sevenDay,
+        fiveHourReset: polled.fiveHourReset ?? prev.fiveHourReset,
+        sevenDayReset: polled.sevenDayReset ?? prev.sevenDayReset,
+        fiveHourStale: false,
+      }
+      this._persistUsage()
       this.notify()
     } catch {
-      // Network error — double the interval (exponential backoff)
+      // Network error — clear rate-limit flag (different failure type), double interval
+      this._usageRateLimited = false
       this._usageCurrentInterval = Math.min(this._usageCurrentInterval * 2, this._usageMaxInterval)
+      this._startFiveHourStaleTimerIfNeeded()
     } finally {
       this._usageInflight = false
     }
   }
 
   private _scheduleNextPoll() {
+    if (!this._usagePollingStarted) return
     if (this._usageTimer) clearTimeout(this._usageTimer)
     this._usageTimer = setTimeout(async () => {
       await this._fetchUsage()
@@ -72,6 +206,9 @@ class WorkspaceStore {
   startUsagePolling() {
     if (this._usagePollingStarted) return
     this._usagePollingStarted = true
+
+    // Restore last known values immediately so UI isn't blank on startup
+    this._loadPersistedUsage()
 
     // Initial fetch
     this._fetchUsage().then(() => this._scheduleNextPoll())
@@ -92,12 +229,49 @@ class WorkspaceStore {
     document.addEventListener('visibilitychange', this._visibilityHandler)
   }
 
+  /** Update usage from SDK rate_limit_event — no API call needed.
+   *  utilization may be undefined (SDK often omits it); resetsAt is usually present. */
+  applyRateLimitEvent(info: { rateLimitType: string; utilization?: number; resetsAt?: number }) {
+    const prev = this._claudeUsage ?? { fiveHour: null, sevenDay: null, fiveHourReset: null, sevenDayReset: null }
+    const resetIso = info.resetsAt ? new Date(info.resetsAt).toISOString() : null
+    if (info.rateLimitType === 'five_hour') {
+      this._clearFiveHourStaleTimer()
+      this._claudeUsage = {
+        ...prev,
+        fiveHour: info.utilization ?? prev.fiveHour,     // keep existing if SDK omits
+        fiveHourReset: resetIso ?? prev.fiveHourReset,
+        fiveHourStale: false,
+      }
+    } else if (info.rateLimitType === 'seven_day' || info.rateLimitType === 'seven_day_opus' || info.rateLimitType === 'seven_day_sonnet') {
+      this._claudeUsage = {
+        ...prev,
+        sevenDay: info.utilization ?? prev.sevenDay,
+        sevenDayReset: resetIso ?? prev.sevenDayReset,
+      }
+    }
+    this._persistUsage()
+    this.notify()
+  }
+
   /** Call after agent activity (turn completed, session ended) for a timely refresh */
   refreshUsageNow() {
     if (!this._usagePollingStarted) return
-    // Use shorter interval temporarily after activity
+    // Skip if in rate-limit backoff — hammering a rate-limited endpoint only extends the ban
+    if (this._usageRateLimited) return
+    if (this._usageTimer) { clearTimeout(this._usageTimer); this._usageTimer = null }
     this._usageCurrentInterval = this._usageMinInterval
     this._fetchUsage().then(() => this._scheduleNextPoll())
+  }
+
+  /** Release all polling resources (timers + event listeners) */
+  stopUsagePolling() {
+    if (this._usageTimer) { clearTimeout(this._usageTimer); this._usageTimer = null }
+    this._clearFiveHourStaleTimer()
+    if (this._visibilityHandler) {
+      document.removeEventListener('visibilitychange', this._visibilityHandler)
+      this._visibilityHandler = null
+    }
+    this._usagePollingStarted = false
   }
 
   getState(): AppState {
@@ -267,7 +441,7 @@ class WorkspaceStore {
   }
 
   // Terminal actions
-  addTerminal(workspaceId: string, agentPreset?: AgentPresetId): TerminalInstance {
+  addTerminal(workspaceId: string, agentPreset?: AgentPresetId, options?: { model?: string }): TerminalInstance {
     const workspace = this.state.workspaces.find(w => w.id === workspaceId)
     if (!workspace) throw new Error('Workspace not found')
 
@@ -289,7 +463,8 @@ class WorkspaceStore {
       title,
       cwd: workspace.folderPath,
       scrollbackBuffer: [],
-      lastActivityTime: Date.now()
+      lastActivityTime: Date.now(),
+      ...(options?.model ? { model: options.model } : {}),
     }
 
     // Auto-focus if it's an agent terminal or no current focus
@@ -366,23 +541,21 @@ class WorkspaceStore {
   }
 
   appendScrollback(id: string, data: string): void {
-    this.state = {
-      ...this.state,
-      terminals: this.state.terminals.map(t =>
-        t.id === id ? { ...t, scrollbackBuffer: [...t.scrollbackBuffer, data] } : t
-      )
-    }
-    // Don't notify for scrollback updates to avoid re-renders
+    // Direct mutation — no notify() means React never reads this via subscription,
+    // so immutability provides no benefit; avoids O(n) spread on every PTY data event
+    const terminal = this.state.terminals.find(t => t.id === id)
+    if (terminal) terminal.scrollbackBuffer.push(data)
   }
 
   clearScrollback(id: string): void {
+    // Immutable update + notify: clears the buffer AND triggers re-render so UI reflects empty state.
+    // Must replace the array reference so any component reading scrollbackBuffer sees the change.
     this.state = {
       ...this.state,
       terminals: this.state.terminals.map(t =>
         t.id === id ? { ...t, scrollbackBuffer: [] } : t
       )
     }
-
     this.notify()
   }
 

--- a/src/styles/claude-agent.css
+++ b/src/styles/claude-agent.css
@@ -1156,23 +1156,6 @@
   color: #ccc;
 }
 
-.claude-1m-toggle {
-  font-size: calc(var(--claude-font-size) - 3px);
-  font-weight: 600;
-  opacity: 0.4;
-  border: 1px solid rgba(255, 255, 255, 0.15);
-  border-radius: 3px;
-  padding: 0 5px;
-}
-.claude-1m-toggle:hover {
-  opacity: 0.7;
-}
-.claude-1m-toggle.active {
-  opacity: 1;
-  color: #6cf;
-  border-color: #6cf;
-}
-
 .claude-status-spacer {
   flex: 1;
 }
@@ -1684,11 +1667,24 @@
   text-decoration: underline;
 }
 
+.claude-usage-low {
+  color: #98c379;
+}
 .claude-usage-mid {
   color: #e6a700;
 }
 .claude-usage-high {
   color: #e05252;
+}
+.claude-usage-stale {
+  opacity: 0.45;
+}
+.claude-usage-overpace {
+  animation: usage-pulse 2s ease-in-out infinite;
+}
+@keyframes usage-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.5; }
 }
 
 /* ============================================

--- a/src/styles/resize.css
+++ b/src/styles/resize.css
@@ -105,63 +105,40 @@
   gap: 4px;
 }
 
-.thumbnail-add-btn {
+.thumbnail-action-btn {
   background: transparent;
   border: 1px solid var(--border-color);
   color: var(--text-secondary);
-  font-size: 14px;
+  font-size: 11px;
   cursor: pointer;
-  padding: 2px 8px;
-  border-radius: 4px;
+  padding: 2px 6px;
+  border-radius: 3px;
   transition: all 0.15s;
   line-height: 1;
-}
-
-.thumbnail-add-btn:hover {
-  background: var(--bg-hover);
-  color: var(--text-primary);
-  border-color: var(--accent-color);
-}
-
-.thumbnail-add-wrapper {
-  position: relative;
-}
-
-.thumbnail-add-menu {
-  position: absolute;
-  top: 100%;
-  right: 0;
-  margin-top: 4px;
-  background: var(--bg-secondary);
-  border: 1px solid var(--border-color);
-  border-radius: var(--radius-sm);
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
-  min-width: 160px;
-  z-index: 100;
-  padding: 4px 0;
-}
-
-.thumbnail-add-menu-item {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 8px 14px;
-  font-size: 13px;
-  color: var(--text-primary);
-  cursor: pointer;
-  transition: background 0.12s;
   white-space: nowrap;
 }
-
-.thumbnail-add-menu-item:hover {
-  background: var(--bg-hover);
+.thumbnail-action-btn:hover {
+  color: var(--text-primary);
 }
-
-.thumbnail-add-menu-icon {
-  font-size: 14px;
-  width: 18px;
-  text-align: center;
-  flex-shrink: 0;
+.thumbnail-action-claude:hover {
+  border-color: #d97706;
+  color: #d97706;
+}
+.thumbnail-action-claude1m:hover {
+  border-color: #6cf;
+  color: #6cf;
+}
+.thumbnail-action-opus:hover {
+  border-color: #c084fc;
+  color: #c084fc;
+}
+.thumbnail-action-sonnet:hover {
+  border-color: #6cf;
+  color: #6cf;
+}
+.thumbnail-action-terminal:hover {
+  border-color: var(--accent-color);
+  color: var(--text-primary);
 }
 
 .thumbnail-collapse-btn {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -210,7 +210,6 @@ export interface AppSettings {
   defaultTerminalCount: number;   // 每個 workspace 預設的 terminal 數量
   createDefaultAgentTerminal: boolean;  // 是否預設建立 Agent Terminal
   allowBypassPermissions: boolean;  // 允許切換 bypassPermissions 模式時不再確認
-  enable1MContext: boolean;  // 啟用 1M token context (僅 Sonnet 4/4.5)
   defaultModel?: string;     // 預設模型（空 = 使用 SDK 預設）
   defaultEffort?: 'low' | 'medium' | 'high' | 'max';  // 預設 effort level
   showDockBadge?: boolean;               // Dock 圖示顯示待處理數量

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
           build: {
             outDir: 'dist-electron',
             rollupOptions: {
-              external: ['@lydell/node-pty', 'ws', 'bufferutil', 'utf-8-validate']
+              external: ['@lydell/node-pty', 'ws', 'bufferutil', 'utf-8-validate', 'sql.js']
             }
           }
         }


### PR DESCRIPTION
## Summary

- Replace Chrome/Edge cookie extraction (broken by App-Bound Encryption v20 on Chrome 127+) with **Firefox cookies.sqlite** — plaintext `sessionKey`, no decryption needed
- Firefox profile resolved from `profiles.ini`: `[Install*]` section `Default` → `[Profile*]` fallback; supports `IsRelative` flag
- Cross-platform: Windows (`%APPDATA%`), macOS (`~/Library/Application Support/`), Linux (standard + Snap + Flatpak paths)
- Cookie path cached on first call; EBUSY (Firefox running) skips re-read for 10min, returns stale cache
- Session key cached 30min; org ID fetched via `claude.ai/api/organizations` with session cookie
- OAuth (`/api/oauth/usage`) remains as fallback when Firefox cookie unavailable
- Replace `better-sqlite3` (native) with `sql.js` (WASM) — avoids Electron ABI mismatch
- Add `sql.js` to vite rollup externals

## Dependencies

> ⚠️ This PR is based on #62 → #61 — merge those first.

## Changed files (5)

| File | Change |
|------|--------|
| `electron/main.ts` | Remove Chrome/Edge DPAPI/AES extraction, add Firefox cookie functions |
| `vite.config.ts` | Add `sql.js` to rollup externals |
| `CLAUDE.md` | Update usage polling docs, add native module guidelines |
| `package.json` | Replace `better-sqlite3` with `sql.js`, remove `@img/sharp` |
| `package-lock.json` | Lockfile update |

## Test plan

- [ ] Verify usage polling works with Firefox installed and logged into claude.ai
- [ ] Verify OAuth fallback works when Firefox cookie unavailable
- [ ] Verify EBUSY handling: polling doesn't error when Firefox is running
- [ ] Check debug.log for `[usage:firefox]` and `[usage:orgId]` entries
- [ ] Verify build succeeds (sql.js WASM loads correctly at runtime)

🤖 Generated with [Claude Code](https://claude.com/claude-code)