### PR TITLE
fix: 切換 model 不再清空訊息輸入框

### DIFF
--- a/src/components/ClaudeAgentPanel.tsx
+++ b/src/components/ClaudeAgentPanel.tsx
@@ -2668,8 +2668,10 @@ export function ClaudeAgentPanel({ sessionId, cwd, isActive, workspaceId, showUs
       )}
 
       {/* Input area — hidden when permission card, ask-user card, or resume/model list is visible */}
-      {!pendingPermission && !pendingQuestion && !showResumeList && !showModelList && (
-      <div className={`claude-input-area${isDragOver ? ' drag-over' : ''}`}>
+      <div
+        className={`claude-input-area${isDragOver ? ' drag-over' : ''}`}
+        style={pendingPermission || pendingQuestion || showResumeList || showModelList ? { display: 'none' } : undefined}
+      >
         {/* Prompt suggestion chip */}
         {promptSuggestion && !isStreaming && (
           <div className="claude-prompt-suggestion" onClick={() => {
@@ -2820,7 +2822,6 @@ export function ClaudeAgentPanel({ sessionId, cwd, isActive, workspaceId, showUs
           </div>
         </div>
       </div>
-      )}
 
       {/* Plan Modal */}
       {contentModal && (


### PR DESCRIPTION
### Summary
- 開啟 model 選單時，訊息輸入框的內容**不再被清空**

### Root Cause
`showModelList` 條件式 rendering 讓整個 input area（含 `<textarea>`）在開啟 model 選單時 **unmount**，關閉後重新 mount 為全新 DOM 元素。由於 textarea 使用 `defaultValue=""` 為 uncontrolled input，remount 後從空值開始，導致用戶已輸入的內容消失。

### Fix
將條件式 unmount 改為 CSS `style={{ display: 'none' }}`，讓 textarea 保持 mounted、只是視覺隱藏，輸入內容完整保留。

### Test plan
- 輸入框打字 → 點擊 model 按鈕 → 按 Esc 取消 → 輸入框內容保留 ✓