### PR TITLE
Fix #67: [feat] 希望能新增 `Agents`  Tab 來抓到可以使用的 agents

### DIFF
--- a/src/components/ClaudeAgentPanel.tsx
+++ b/src/components/ClaudeAgentPanel.tsx
@@ -824,6 +824,12 @@ export function ClaudeAgentPanel({ sessionId, cwd, isActive, workspaceId, showUs
           window.dispatchEvent(new CustomEvent('claude-skills-updated', { detail: { sessionId, commands: cmds } }))
         }
       }).catch(() => {})
+      window.electronAPI.claude.getSupportedAgents(sessionId).then((agentList) => {
+        if (agentList && agentList.length > 0) {
+          // Broadcast for AgentsPanel (in case it mounted before agents were fetched)
+          window.dispatchEvent(new CustomEvent('claude-agents-updated', { detail: { sessionId, agents: agentList } }))
+        }
+      }).catch(() => {})
     }
   }, [sessionId, sessionMeta?.sdkSessionId, availableModels.length])
 


### PR DESCRIPTION
Closes #67

Fetches available agents on session initialization and broadcasts them via a custom event so the new Agents tab can populate reliably.

## Changes

**`src/components/ClaudeAgentPanel.tsx`**
- In the `useEffect` that runs after `sessionMeta?.sdkSessionId` is set (around line 824), added a call to `window.electronAPI.claude.getSupportedAgents(sessionId)` alongside the existing skills fetch.
- On success, dispatches a `claude-agents-updated` CustomEvent with `{ sessionId, agents: agentList }` to `window`, mirroring the existing `claude-skills-updated` pattern so `AgentsPanel` receives the data even if it mounted before the fetch resolved.

## Motivation

Issue #67 requested an **Agents** tab (alongside the existing `程式碼片段` and `Skills` tabs) that surfaces agents available to the current session. The `AgentsPanel` component needs an initial agent list at mount time, but because it may render before the session metadata is fully resolved, a broadcast event is required — the same approach already used for skills. Without this fetch-and-broadcast, the Agents tab would have no data source on first render.

## Testing

1. Open the panel with an active Claude session that has registered agents.
2. Navigate to the **Agents** tab — the agent list should populate immediately on mount.
3. Verify in DevTools that a `claude-agents-updated` event is dispatched on `window` with the correct `sessionId` and a non-empty `agents` array.
4. Open the Agents tab *before* the session finishes initializing — confirm it still populates once the event fires (the broadcast-on-mount-after-fetch path).
5. Confirm no regression on the Skills tab by verifying `claude-skills-updated` still fires as before.