### PR TITLE
fix(remote): make workspace:load + window identity work when connected to remote host

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1287,6 +1287,11 @@ function registerProxiedHandlers() {
 
   // Profile (subset exposed to remote clients)
   registerHandler('profile:list', (_ctx) => profileManager.list())
+  // Local-only profile list (never proxied to remote). Used by the renderer
+  // to resolve the window's own identity when connected to a remote host,
+  // since the proxied profile:list returns the REMOTE host's profiles and
+  // the client's local aliases won't be found there.
+  ipcMain.handle('profile:list-local', () => profileManager.list())
   registerHandler('profile:load', (_ctx, profileId: string) => profileManager.load(profileId))
   registerHandler('profile:load-snapshot', (_ctx, profileId: string) => profileManager.loadSnapshot(profileId))
   registerHandler('profile:get-active-ids', (_ctx) => profileManager.getActiveProfileIds())

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1296,11 +1296,21 @@ function registerProxiedHandlers() {
 
 // ── Bind all proxied handlers to ipcMain ──
 
+// Channels that MUST run locally even when connected to a remote host.
+// These handlers depend on ctx.windowId which the remote protocol doesn't
+// forward; proxying them would return null and break the UI.
+// The snapshot data for workspaces is already replicated into the local
+// windowRegistry via applySnapshot() at startup, so reading locally works.
+const ALWAYS_LOCAL_CHANNELS = new Set([
+  'workspace:save', 'workspace:load',
+])
+
 function bindProxiedHandlersToIpc() {
   for (const channel of PROXIED_CHANNELS) {
     ipcMain.handle(channel, async (event, ...args: unknown[]) => {
-      // If remote client is connected, route to remote server
-      if (remoteClient?.isConnected) {
+      // If remote client is connected, route to remote server — unless this
+      // channel is pinned to local execution.
+      if (remoteClient?.isConnected && !ALWAYS_LOCAL_CHANNELS.has(channel)) {
         return remoteClient.invoke(channel, args)
       }
       const windowId = getWindowIdByWebContents(event.sender)

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -301,6 +301,10 @@ const electronAPI = {
   },
   profile: {
     list: () => ipcRenderer.invoke('profile:list') as Promise<{ profiles: { id: string; name: string; type: 'local' | 'remote'; remoteHost?: string; remotePort?: number; remoteToken?: string; remoteProfileId?: string; createdAt: number; updatedAt: number }[]; activeProfileIds: string[] }>,
+    // Local-only profile list — returns THIS machine's profiles even when
+    // connected to a remote host (where profile:list would return the remote's
+    // profiles). Used to resolve window identity / local aliases.
+    listLocal: () => ipcRenderer.invoke('profile:list-local') as Promise<{ profiles: { id: string; name: string; type: 'local' | 'remote'; remoteHost?: string; remotePort?: number; remoteToken?: string; remoteProfileId?: string; createdAt: number; updatedAt: number }[]; activeProfileIds: string[] }>,
     create: (name: string, options?: { type?: 'local' | 'remote'; remoteHost?: string; remotePort?: number; remoteToken?: string; remoteProfileId?: string }) =>
       ipcRenderer.invoke('profile:create', name, options) as Promise<{ id: string; name: string; type: 'local' | 'remote'; createdAt: number; updatedAt: number }>,
     save: (profileId: string) => ipcRenderer.invoke('profile:save', profileId) as Promise<boolean>,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -303,7 +303,21 @@ export default function App() {
         // 3. First active profile as fallback
         const windowProfileId = await window.electronAPI.app.getWindowProfile()
         const profileId = launchProfileId || windowProfileId || result.activeProfileIds[0]
-        const active = result.profiles.find(p => p.id === profileId)
+        let active = result.profiles.find(p => p.id === profileId)
+
+        // If the id doesn't match anything in `result` (which is the REMOTE
+        // host's profile list when a remote connection is already active),
+        // fall back to the local profile list. This happens when the window
+        // is bound to a LOCAL profile that acts as an alias for a remote
+        // connection (e.g. launched with --profile=<local-remote-alias>).
+        if (!active && profileId) {
+          try {
+            const localResult = await window.electronAPI.profile.listLocal()
+            active = localResult.profiles.find(p => p.id === profileId)
+          } catch {
+            // listLocal may not exist on older builds — fall through
+          }
+        }
 
         if (active?.type === 'remote' && active.remoteHost && active.remoteToken) {
           // Try connecting to remote


### PR DESCRIPTION
## Summary

Two related fixes for the BAT-to-BAT remote protocol. Symptom when a client connects to a remote host: the window shows the empty "歡迎使用 Better Agent Terminal" welcome screen and the title falls back to `Default:1:1`, even though the main process successfully connected to the remote and fetched the snapshot.

## Root causes

### 1. `workspace:load` / `workspace:save` lose `ctx.windowId` through the proxy
`remote-server.ts:130` calls `invokeHandler(frame.channel, args)` without forwarding the originating window id. The `workspace:load` handler in `main.ts` starts with `if (!ctx.windowId) return null`, so proxied calls always return null and the client shows an empty workspace list — even though the local `windowRegistry` was already populated from the remote snapshot by `applySnapshot()` at startup.

### 2. Renderer can't resolve its own identity when connected
In `App.tsx` `initProfile`, `profile.list()` is proxied to the remote host once `remoteClient.isConnected`. The returned profiles are the REMOTE host's (e.g. `[{id: "default", ...}]`), so `result.profiles.find(p => p.id === profileId)` fails when `profileId` is the CLIENT's local alias for the remote (e.g. `"mac-studio"`). The code then falls through to the "first local profile" branch and sets the title to "Default", and it skips the `remote.connect` path entirely since `active` is undefined.

## Changes

**Fix 1 — `electron/main.ts`**: Add `ALWAYS_LOCAL_CHANNELS = { 'workspace:save', 'workspace:load' }`. `bindProxiedHandlersToIpc` skips the remote proxy for these channels so they read/write the client's local `windowRegistry`, which already contains the snapshot from the remote host.

**Fix 2 — `electron/main.ts` + `electron/preload.ts` + `src/App.tsx`**: Add a new `profile:list-local` IPC (not in `PROXIED_CHANNELS`) and expose it as `electronAPI.profile.listLocal()`. In `App.tsx` `initProfile`, if `active` doesn't match anything in the proxied list, fall back to `listLocal()` so the window can find its own local alias entry (which has `type: 'remote'`, `remoteHost`, `remoteToken`) and continue into the normal remote-connect branch.

## Repro

1. On host A, enable the remote server.
2. On host B, add a remote profile pointing at A, launch with `--profile=<that-id>`.
3. Before: welcome screen, title `Default:1:1`, no `[init] remote.connect` log entry in the renderer.
4. After: host A's workspaces + terminals visible, title shows the local alias (e.g. `Mac Studio:1`), `[init] remote.connect` runs.

## Test plan

- [x] Launch client with `--profile=<remote-alias>` → connects, workspaces & terminals visible, title shows local alias name
- [x] `hostname` inside the proxied terminal resolves to the REMOTE host (confirming the PTY is on the remote side)
- [ ] Existing local-only BAT usage still works (no regression for `workspace:load/save` when `remoteClient` is not connected — same code path as before)
- [ ] Profile switcher UI still works when connected (proxied `profile:list` still returns remote's profiles for profile operations)