### PR TITLE
docs: fix escaped backtick formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,8 +166,8 @@ After installing, run `cx lang add <language>` for each language you want gramma
 
 | Shortcut | Action |
 |---|---|
-| `Ctrl+`` ` `` (Windows) | Switch to the next BAT window |
-| `Cmd+`` ` `` (macOS) / `Ctrl+`` ` `` (Linux) | Toggle between Agent terminal and first regular terminal |
+| `` Ctrl+` `` (Windows) | Switch to the next BAT window |
+| `` Cmd+` `` (macOS) / `` Ctrl+` `` (Linux) | Toggle between Agent terminal and first regular terminal |
 | `Ctrl+←/→` / `Cmd+←/→` | Cycle workspace tabs (Terminal / Files / Git) |
 | `Ctrl+↑/↓` / `Cmd+↑/↓` | Switch to previous / next workspace |
 | `Ctrl+P` / `Cmd+P` | File picker (search & attach files to agent context) |

--- a/release-note.md
+++ b/release-note.md
@@ -5,7 +5,7 @@
 ### New Features
 
 #### Keyboard Shortcuts (#68)
-- `Ctrl+`` ` `` / `Cmd+`` ` ``: Toggle between Agent terminal and first regular terminal (press again to switch back)
+- `` Ctrl+ ` `` / `` Cmd+` ``: Toggle between Agent terminal and first regular terminal (press again to switch back)
 - `Ctrl+←/→` / `Cmd+←/→`: Cycle workspace tabs (Terminal → Files → Git)
 - `Ctrl+↑/↓` / `Cmd+↑/↓`: Switch to previous / next workspace (wraps around)
 


### PR DESCRIPTION
Backticks in inline code blocks in Markdown are escaped by delimiting the inline code blocks with multi-backtick tokens; the string ``` `` ` `` ``` does not magically get replaced with a inline code backtick.

`` Ctrl+` `` is ``` `` Ctrl+` `` ```, not ``` `Ctrl+`` ` `` ```.

---

This was something I had to relearn. Some examples [I posted elsewhere](https://gist.github.com/mcandre/8d76e076b2495fd8b36f439ec5033116?permalink_comment_id=6130126#gistcomment-6130126):

```
``inline code using double backticks - a single ` is included verbatim``
```inline code using triple backticks - so `, ``, ```` etc. can all be included verbatim```
``````````That was ten, so ` `` ``` ```` etc. can all be included verbatim at the cost of the delimiter being a bit ridiculous``````````
``` ends with a backtick but surrounded by spaces, the spaces are removed` ```
```ends with a backtick but not surrounded by spaces, the final space is not removed` ```
```

Result:

``inline code using double backticks - a single ` is included verbatim``
```inline code using triple backticks - so `, ``, ```` etc. can all be included verbatim```
``````````That was ten, so ` `` ``` ```` etc. can all be included verbatim at the cost of the delimiter being a bit ridiculous``````````
``` ends with a backtick but surrounded by spaces, the spaces are removed` ```
```ends with a backtick but not surrounded by spaces, the final space is not removed` ```