### PR TITLE
feat: optionally close terminal after process exits

### DIFF
--- a/src/components/MainPanel.tsx
+++ b/src/components/MainPanel.tsx
@@ -209,7 +209,12 @@ export const MainPanel = memo(function MainPanel({ terminal, isActive, onClose, 
             )}
           </Suspense>
         ) : (
-          <TerminalPanel terminalId={terminal.id} isActive={isActive} agentPreset={terminal.agentPreset} />
+          <TerminalPanel
+            terminalId={terminal.id}
+            isActive={isActive}
+            onClose={onClose}
+            agentPreset={terminal.agentPreset}
+          />
         )}
       </div>
       {!isClaudeCode && showPromptBox && (

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -465,6 +465,12 @@ export function SettingsPanel({ onClose }: SettingsPanelProps) {
                     onChange={e => settingsStore.setDefaultTerminalCount(Number(e.target.value))}
                   />
                 </div>
+                <div className="settings-group checkbox-group">
+                  <label>
+                    <input type="checkbox" checked={settings.closeTerminalAfterProcessExit !== false} onChange={e => settingsStore.setCloseTerminalAfterProcessExit(e.target.checked)} />
+                    {t('settings.closeTerminalAfterProcessExit')}
+                  </label>
+                </div>
               </div>
 
               <div className="settings-section">

--- a/src/components/TerminalPanel.tsx
+++ b/src/components/TerminalPanel.tsx
@@ -12,6 +12,7 @@ const dlog = (...args: unknown[]) => window.electronAPI?.debug?.log(...args)
 
 interface TerminalPanelProps {
   terminalId: string
+  onClose?: (id: string) => void
   isActive?: boolean
   terminalType?: 'terminal' | 'code-agent'
   agentPreset?: AgentPresetId
@@ -31,7 +32,7 @@ function getWindowsBuildNumber(): number | undefined {
 }
 
 let renderCount = 0
-export const TerminalPanel = memo(function TerminalPanel({ terminalId, isActive = true, terminalType, agentPreset }: TerminalPanelProps) {
+export const TerminalPanel = memo(function TerminalPanel({ terminalId, onClose, isActive = true, terminalType, agentPreset }: TerminalPanelProps) {
   renderCount++
   if (renderCount <= 50 || renderCount % 50 === 0) {
     dlog(`[render] TerminalPanel render #${renderCount} terminal=${terminalId} active=${isActive}`)
@@ -461,6 +462,9 @@ export const TerminalPanel = memo(function TerminalPanel({ terminalId, isActive 
     const unsubscribeExit = window.electronAPI.pty.onExit((id, exitCode) => {
       if (id === terminalId) {
         terminal.write(`\r\n\x1b[90m[Process exited with code ${exitCode}]\x1b[0m\r\n`)
+        if (settingsStore.getCloseTerminalAfterProcessExit()) {
+          onClose?.(terminalId)
+        }
       }
     })
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -37,6 +37,7 @@
     "defaultShell": "Default Shell",
     "customShellPath": "Custom Shell Path",
     "defaultTerminalCount": "Default Terminals per Workspace: {{count}}",
+    "closeTerminalAfterProcessExit": "Close Terminal After Process Exits",
     "createAgentTerminalByDefault": "Create Agent Terminal by default",
     "createAgentTerminalHint": "When enabled, new workspaces will include an Agent Terminal.",
     "defaultAgent": "Default Agent",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -35,6 +35,7 @@
     "defaultShell": "默认 Shell",
     "customShellPath": "自定义 Shell 路径",
     "defaultTerminalCount": "每个工作区默认终端数量：{{count}}",
+    "closeTerminalAfterProcessExit": "程序结束后自动关闭终端",
     "createAgentTerminalByDefault": "默认创建 Agent 终端",
     "createAgentTerminalHint": "启用后，新工作区将自动包含一个 Agent 终端。",
     "defaultAgent": "默认 Agent",

--- a/src/locales/zh-TW.json
+++ b/src/locales/zh-TW.json
@@ -37,6 +37,7 @@
     "defaultShell": "預設 Shell",
     "customShellPath": "自訂 Shell 路徑",
     "defaultTerminalCount": "每個工作區預設終端數量：{{count}}",
+    "closeTerminalAfterProcessExit": "程序結束後自動關閉終端機",
     "createAgentTerminalByDefault": "預設建立 Agent 終端",
     "createAgentTerminalHint": "啟用後，新工作區將自動包含一個 Agent 終端。",
     "defaultAgent": "預設 Agent",

--- a/src/stores/settings-store.ts
+++ b/src/stores/settings-store.ts
@@ -33,6 +33,7 @@ const defaultSettings: AppSettings = {
   agentCommandType: 'claude',
   agentCustomCommand: '',
   defaultTerminalCount: 1,
+  closeTerminalAfterProcessExit: false,
   createDefaultAgentTerminal: true,
   allowBypassPermissions: true,
   defaultEffort: 'high',
@@ -177,6 +178,12 @@ class SettingsStore {
 
   setDefaultTerminalCount(count: number): void {
     this.settings = { ...this.settings, defaultTerminalCount: Math.max(1, Math.min(5, count)) }
+    this.notify()
+    this.save()
+  }
+
+  setCloseTerminalAfterProcessExit(close: boolean): void {
+    this.settings = { ...this.settings, closeTerminalAfterProcessExit: close }
     this.notify()
     this.save()
   }
@@ -335,6 +342,10 @@ class SettingsStore {
     this.settings = { ...this.settings, remoteServerBindInterface: bindInterface }
     this.notify()
     this.save()
+  }
+
+  getCloseTerminalAfterProcessExit(): boolean {
+    return this.settings.closeTerminalAfterProcessExit
   }
 
   // Get the agent command to execute

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -231,6 +231,7 @@ export interface AppSettings {
   agentCommandType: AgentCommandType;  // Agent 命令類型
   agentCustomCommand: string;     // 自定義 Agent 命令
   defaultTerminalCount: number;   // 每個 workspace 預設的 terminal 數量
+  closeTerminalAfterProcessExit: boolean;  // 程序結束後是否自動關閉終端機
   createDefaultAgentTerminal: boolean;  // 是否預設建立 Agent Terminal
   allowBypassPermissions: boolean;  // 允許切換 bypassPermissions 模式不再確認；同時讓 Codex 以 danger-full-access 啟動
   defaultModel?: string;     // Legacy Claude 預設模型（保留用於遷移）


### PR DESCRIPTION
When I exit a shell in a terminal panel, I want the panel to also exit with it. This change implements that as an option.

https://github.com/user-attachments/assets/bb7182de-7ecb-46bf-b8ae-6418e4be25b8

A getter is made for the option because otherwise I'd be reading the value of the option when the terminal was created, not when the process has just ended. If I changed the option in the mean time it should read the updated value (via the getter) and not the old value.

I wrote this change itself manually, although I was racing an agent in the background to evaluate how well it does. It produced more or less the same code, though with less clear strings, more wordy comments, and it accessed workspaceStore.removeTerminal from TerminalPanel directly instead of (properly) going through the onClose function.