### PR TITLE
feat: keyboard shortcuts for opening and closing new terminals

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,8 @@ After installing, run `cx lang add <language>` for each language you want gramma
 | `Ctrl+↑/↓` / `Cmd+↑/↓` | Switch to previous / next workspace |
 | `Ctrl+P` / `Cmd+P` | File picker (search & attach files to agent context) |
 | `Ctrl+N` / `Cmd+N` | Open new window |
+| `Ctrl+Shift+T` / `Cmd+T`  | Open new terminal |
+| `Ctrl+Shift+W` / `Cmd+W`  | Close current terminal |
 | `Shift+Tab` | Switch between Terminal and Agent mode |
 | `Enter` | Send message |
 | `Shift+Enter` | Insert newline (multiline input) |

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -306,6 +306,38 @@ export default function App() {
         workspaceStore.setActiveWorkspace(workspaces[nextIndex].id)
         return
       }
+
+      // Cmd+t or Ctrl+Shift+T: Open new terminal
+      if (
+        (e.metaKey && !e.shiftKey && e.key === "t") ||
+        (e.ctrlKey && e.shiftKey && e.key === "T")
+      ) {
+        e.preventDefault()
+        const currentState = workspaceStore.getState()
+        if (currentState.activeWorkspaceId) {
+          // Ensure we're on the terminal tab
+          window.dispatchEvent(new CustomEvent('workspace-switch-tab', { detail: { tab: 'terminal' } }))
+          window.dispatchEvent(new CustomEvent('workspace-add-terminal'))
+        }
+        return
+      }
+
+      // Cmd+w or Ctrl+Shift+W: Close current terminal
+      if (
+        (e.metaKey && !e.shiftKey && e.key === "w") ||
+        (e.ctrlKey && e.shiftKey && e.key === "W")
+      ) {
+        e.preventDefault()
+        const currentState = workspaceStore.getState()
+        if (currentState.focusedTerminalId) {
+          window.dispatchEvent(
+            new CustomEvent("workspace-close-terminal", {
+              detail: { terminalId: currentState.focusedTerminalId },
+            }),
+          );
+        }
+        return
+      }
     }
     window.addEventListener('keydown', handler)
     return () => window.removeEventListener('keydown', handler)

--- a/src/components/WorkspaceView.tsx
+++ b/src/components/WorkspaceView.tsx
@@ -363,6 +363,25 @@ export function WorkspaceView({ workspace, terminals, focusedTerminalId, isActiv
     workspaceStore.save()
   }, [workspace.id, workspace.folderPath, workspace.envVars])
 
+  // Listen for keyboard shortcut events to create new terminals
+  useEffect(() => {
+    if (!isActive) return
+    // Like `handleCloseTerminal` except with the current terminal ID filled in
+    function handleAppCloseTerminalEvent(e: Event) {
+      const { terminalId } = (e as CustomEvent).detail as { terminalId: string }
+      // Only close terminal when in the terminal tab
+      if (activeTab === 'terminal' && terminalId) {
+        handleCloseTerminal(terminalId)
+      }
+    }
+    window.addEventListener('workspace-add-terminal', handleAddTerminal)
+    window.addEventListener('workspace-close-terminal', handleAppCloseTerminalEvent)
+    return () => {
+      window.removeEventListener('workspace-add-terminal', handleAddTerminal)
+      window.removeEventListener('workspace-close-terminal', handleAppCloseTerminalEvent)
+    }
+  }, [isActive, activeTab])
+
   const handleAddWorktreeTerminal = useCallback(async () => {
     const terminal = workspaceStore.addTerminal(workspace.id)
     const wtResult = await window.electronAPI.worktree.create(terminal.id, workspace.folderPath)


### PR DESCRIPTION
- Cmd+t (like macOS Terminal) or Ctrl+Shift+T (like Konsole) to open a new terminal in the current workspace. This works regardless of which Tab (github, files, terminal, git) the user is in.

- Cmd+w (like macOS Terminal) or Ctrl+Shift+W (like Konsole) to close the currently active terminal. This only works when the terminal Tab is active, because an "active" terminal in an inactive tab is conceptually not active (and thus closing a terminal in the background is surprising).

An initial version of this change was done with Gemini 2.5 Flash within Pi. It recognized App.tsx as the place for global shortcuts but implemented it by directly calling workspaceStore.addTerminal and workspaceStore.removeTerminal. The removal happens to work but the addTerminal breaks, because there are important setup steps happening in WorkspaceView's handleAddTerminal that this naive approach doesn't work with. After a second prompt led to it writing complicated broken magic purely in App.tsx, I tossed it out and wrote the current version based on how workspace-cycle-tab and workspace-switch-tab are already implemented.