### PR TITLE
notifications: identify and route entries by workspace

### DIFF
--- a/renderer/src/host-api.ts
+++ b/renderer/src/host-api.ts
@@ -267,6 +267,33 @@ function listenAdapter<T>(
   }
 }
 
+// Stamp the agent session's workspace identity onto the start/resume
+// options. The notification center needs this to label and route entries
+// by workspace — several workspaces can share one cwd and window, so the
+// path alone can't tell them apart. Best-effort: the session id is the
+// terminal id, but if the terminal/workspace can't be resolved we leave
+// the options untouched and the Rust side falls back to the cwd.
+async function attachWorkspaceIdentity(
+  sessionId: string,
+  options: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+  try {
+    const { workspaceStore } = await import('./stores/workspace-store')
+    const state = workspaceStore.getState()
+    const terminal = state.terminals.find(t => t.id === sessionId)
+    if (!terminal) return options
+    const workspace = state.workspaces.find(w => w.id === terminal.workspaceId)
+    if (!workspace) return options
+    return {
+      ...options,
+      workspaceId: workspace.id,
+      workspaceName: workspace.alias?.trim() || workspace.name,
+    }
+  } catch {
+    return options
+  }
+}
+
 const CLAUDE_EVENT_PAYLOAD_KEYS: Record<string, string> = {
   onMessage: 'message',
   onToolUse: 'toolCall',
@@ -337,6 +364,7 @@ type NotificationEntry = {
   sessionId: string
   windowId: string | null
   profileId: string | null
+  workspaceId?: string
   workspaceName: string
   cwd: string
   reason: 'completed' | 'error' | 'aborted'
@@ -566,6 +594,11 @@ function createTauriHost(): BatAppAPI {
         getInvoke()<{ id: string; windowId: string } | null>('notification_focus_entry', { id }),
       onUpdate: (cb: (entries: NotificationEntry[]) => void) =>
         listenAdapter<NotificationEntry[]>('notification:update', cb),
+      // Fired at this window after a notification is focused — payload is
+      // the workspace id the agent ran in, so the renderer can switch to
+      // that workspace tab (focusing the OS window alone isn't enough).
+      onActivateWorkspace: (cb: (workspaceId: string) => void) =>
+        listenAdapter<string>('notification:activate-workspace', cb),
     },
     system: {
       // Tauri does not expose a power-monitor resume event here.
@@ -692,8 +725,13 @@ function createTauriHost(): BatAppAPI {
           return () => getInvoke()<unknown>('claude_account_list')
         }
         if (key === 'startSession') {
-          return (sessionId: string, options: unknown) =>
-            getInvoke()<unknown>('claude_start_session', { sessionId, options })
+          return async (sessionId: string, options: unknown) =>
+            getInvoke()<unknown>('claude_start_session', {
+              sessionId,
+              options: options == null
+                ? options
+                : await attachWorkspaceIdentity(sessionId, options as Record<string, unknown>),
+            })
         }
         if (key === 'sendMessage') {
           return async (
@@ -812,7 +850,7 @@ function createTauriHost(): BatAppAPI {
         // fresh. Renderer panels call this on remount when they have a
         // savedSdkSessionId from a prior run.
         if (key === 'resumeSession') {
-          return (
+          return async (
             sessionId: string,
             sdkSessionId: string,
             cwd: string,
@@ -829,7 +867,7 @@ function createTauriHost(): BatAppAPI {
           ) => getInvoke()<unknown>('claude_resume_session', {
             sessionId,
             sdkSessionId,
-            options: {
+            options: await attachWorkspaceIdentity(sessionId, {
               cwd,
               model,
               apiVersion,
@@ -839,7 +877,7 @@ function createTauriHost(): BatAppAPI {
               ...(codexApprovalPolicy ? { codexApprovalPolicy } : {}),
               ...(permissionMode ? { permissionMode } : {}),
               ...(effort ? { effort } : {}),
-            },
+            }),
           })
         }
         // Account / auth ops.

--- a/renderer/src/stores/notification-store.ts
+++ b/renderer/src/stores/notification-store.ts
@@ -1,10 +1,12 @@
 import { host } from '../host-api'
+import { workspaceStore } from './workspace-store'
 
 export interface NotificationEntry {
   id: string
   sessionId: string
   windowId: string | null
   profileId: string | null
+  workspaceId?: string
   workspaceName: string
   cwd: string
   reason: 'completed' | 'error' | 'aborted'
@@ -22,6 +24,7 @@ class NotificationStore {
   private listeners: Set<Listener> = new Set()
   private subscribed = false
   private unsubscribePush?: () => void
+  private unsubscribeActivate?: () => void
 
   getEntries(): NotificationEntry[] {
     return this.entries
@@ -51,11 +54,22 @@ class NotificationStore {
       this.entries = entries
       this.emit()
     })
+    // When a notification is focused, the host targets this window with
+    // the agent's workspace id. Switch to that workspace tab — focusing
+    // the OS window alone leaves the user on whatever tab was active.
+    this.unsubscribeActivate = host.notification.onActivateWorkspace((workspaceId) => {
+      if (!workspaceId) return
+      if (workspaceStore.getState().workspaces.some((w) => w.id === workspaceId)) {
+        workspaceStore.setActiveWorkspace(workspaceId)
+      }
+    })
   }
 
   dispose(): void {
     this.unsubscribePush?.()
     this.unsubscribePush = undefined
+    this.unsubscribeActivate?.()
+    this.unsubscribeActivate = undefined
     this.subscribed = false
   }
 

--- a/src-tauri/src/commands/claude.rs
+++ b/src-tauri/src/commands/claude.rs
@@ -3896,6 +3896,8 @@ pub async fn claude_resume_session(
             option_field(&options, "codexApprovalPolicy"),
             option_field(&options, "permissionMode"),
             option_field(&options, "effort"),
+            option_field(&options, "workspaceId"),
+            option_field(&options, "workspaceName"),
         ],
         SESSION_TIMEOUT,
     )

--- a/src-tauri/src/commands/claude.rs
+++ b/src-tauri/src/commands/claude.rs
@@ -4441,6 +4441,8 @@ mod tests {
         let session = notification_cmd::AgentNotificationSession {
             window_id: Some("main".into()),
             profile_id: Some("default".into()),
+            workspace_id: None,
+            workspace_name: None,
             cwd: "C:/repo".into(),
             agent_kind: Some("claude".into()),
             model: Some("claude-opus-4-7:auto-compact-300k".into()),
@@ -4476,6 +4478,8 @@ mod tests {
         let session = notification_cmd::AgentNotificationSession {
             window_id: Some("main".into()),
             profile_id: Some("default".into()),
+            workspace_id: None,
+            workspace_name: None,
             cwd: "C:/repo".into(),
             agent_kind: Some("claude".into()),
             model: Some("claude-sonnet-4-6".into()),
@@ -4518,6 +4522,8 @@ mod tests {
         let session = notification_cmd::AgentNotificationSession {
             window_id: Some("main".into()),
             profile_id: Some("default".into()),
+            workspace_id: None,
+            workspace_name: None,
             cwd: "C:/repo".into(),
             agent_kind: Some("claude".into()),
             model: Some("claude-sonnet-4-6".into()),
@@ -4561,6 +4567,8 @@ mod tests {
         let session = notification_cmd::AgentNotificationSession {
             window_id: Some("main".into()),
             profile_id: Some("default".into()),
+            workspace_id: None,
+            workspace_name: None,
             cwd: "C:/repo".into(),
             agent_kind: Some("claude".into()),
             model: Some("claude-sonnet-4-6".into()),
@@ -4593,6 +4601,8 @@ mod tests {
         let session = notification_cmd::AgentNotificationSession {
             window_id: Some("main".into()),
             profile_id: Some("default".into()),
+            workspace_id: None,
+            workspace_name: None,
             cwd: "C:/repo".into(),
             agent_kind: Some("claude".into()),
             model: Some("claude-sonnet-4-6".into()),
@@ -4627,6 +4637,8 @@ mod tests {
         let session = notification_cmd::AgentNotificationSession {
             window_id: Some("main".into()),
             profile_id: Some("default".into()),
+            workspace_id: None,
+            workspace_name: None,
             cwd: "C:/repo".into(),
             agent_kind: Some("claude".into()),
             model: None,

--- a/src-tauri/src/commands/notification.rs
+++ b/src-tauri/src/commands/notification.rs
@@ -35,6 +35,8 @@ pub struct NotificationEntry {
     pub window_id: Option<String>,
     #[serde(rename = "profileId")]
     pub profile_id: Option<String>,
+    #[serde(rename = "workspaceId", skip_serializing_if = "Option::is_none")]
+    pub workspace_id: Option<String>,
     #[serde(rename = "workspaceName")]
     pub workspace_name: String,
     pub cwd: String,
@@ -58,6 +60,8 @@ pub struct NotificationState {
 pub struct AgentNotificationSession {
     pub window_id: Option<String>,
     pub profile_id: Option<String>,
+    pub workspace_id: Option<String>,
+    pub workspace_name: Option<String>,
     pub cwd: String,
     pub agent_kind: Option<String>,
     pub model: Option<String>,
@@ -196,14 +200,21 @@ pub fn notification_focus_latest_unread(
     app: AppHandle,
     state: State<'_, NotificationState>,
 ) -> Option<FocusResult> {
-    let (id, window_id) = {
+    let (id, window_id, workspace_id) = {
         let entries = state.lock();
         entries
             .iter()
             .find(|entry| !entry.read && entry.window_id.is_some())
-            .map(|entry| (entry.id.clone(), entry.window_id.clone().unwrap()))?
+            .map(|entry| {
+                (
+                    entry.id.clone(),
+                    entry.window_id.clone().unwrap(),
+                    entry.workspace_id.clone(),
+                )
+            })?
     };
     focus_notification_window(&app, &window_id)?;
+    activate_notification_workspace(&app, &window_id, workspace_id.as_deref());
     mark_entry_read_and_emit(&app, &state, &id);
     Some(FocusResult { id, window_id })
 }
@@ -214,14 +225,13 @@ pub fn notification_focus_entry(
     state: State<'_, NotificationState>,
     id: String,
 ) -> Option<FocusResult> {
-    let window_id = {
+    let (window_id, workspace_id) = {
         let entries = state.lock();
-        entries
-            .iter()
-            .find(|entry| entry.id == id)
-            .and_then(|entry| entry.window_id.clone())?
+        let entry = entries.iter().find(|entry| entry.id == id)?;
+        (entry.window_id.clone()?, entry.workspace_id.clone())
     };
     focus_notification_window(&app, &window_id)?;
+    activate_notification_workspace(&app, &window_id, workspace_id.as_deref());
     mark_entry_read_and_emit(&app, &state, &id);
     Some(FocusResult { id, window_id })
 }
@@ -240,6 +250,8 @@ pub fn register_agent_session_from_options(
         return;
     }
     let profile_id = Some(window_registry::get_entry(app, window_id).profile_id);
+    let workspace_id = options.and_then(|value| string_option(value, "workspaceId"));
+    let workspace_name = options.and_then(|value| string_option(value, "workspaceName"));
     let agent_kind = options.and_then(agent_kind_from_options);
     let model = options.and_then(|value| string_option(value, "model"));
     let permission_mode = options.and_then(|value| string_option(value, "permissionMode"));
@@ -268,6 +280,8 @@ pub fn register_agent_session_from_options(
         AgentNotificationSession {
             window_id: Some(window_id.to_string()),
             profile_id,
+            workspace_id,
+            workspace_name,
             cwd,
             agent_kind,
             model,
@@ -344,7 +358,10 @@ pub fn add_agent_completion_from_event(app: &AppHandle, topic: &str, payload: &V
             session_id: session_id.to_string(),
             window_id: session.window_id,
             profile_id: session.profile_id,
-            workspace_name: workspace_name(&session.cwd),
+            workspace_id: session.workspace_id,
+            workspace_name: session
+                .workspace_name
+                .unwrap_or_else(|| workspace_name(&session.cwd)),
             cwd: session.cwd,
             reason: "completed".into(),
             result,
@@ -563,6 +580,21 @@ fn focus_notification_window(app: &AppHandle, window_id: &str) -> Option<()> {
     Some(())
 }
 
+// Ask the focused window's renderer to switch to the workspace the agent
+// ran in. Focusing the OS window alone isn't enough — several workspaces
+// can live as tabs inside one window, so without this the user lands on
+// whichever workspace happened to be active. Targeted at the owning
+// window so other windows don't react to an id they don't have.
+fn activate_notification_workspace(app: &AppHandle, window_id: &str, workspace_id: Option<&str>) {
+    if let Some(workspace_id) = workspace_id.filter(|id| !id.is_empty()) {
+        let _ = app.emit_to(
+            window_id,
+            "notification:activate-workspace",
+            workspace_id.to_string(),
+        );
+    }
+}
+
 fn mark_entry_read_and_emit(app: &AppHandle, state: &State<'_, NotificationState>, id: &str) {
     let changed = {
         let mut entries = state.lock();
@@ -596,10 +628,12 @@ fn emit_update(app: &AppHandle, state: &State<'_, NotificationState>) {
 pub fn add_entry(app: &AppHandle, state: &NotificationState, entry: NotificationEntry) {
     {
         let mut entries = state.lock();
-        // Mirror the Electron behaviour: replace any existing entry
-        // for the same workspace key (lowercased path on Windows).
-        let key = normalize_workspace_key(&entry.cwd);
-        entries.retain(|e| normalize_workspace_key(&e.cwd) != key);
+        // One entry per workspace: a fresh completion replaces that
+        // workspace's previous entry. Keyed by workspace id when known,
+        // so sibling workspaces that share a cwd (and window) no longer
+        // collapse into a single notification.
+        let key = entry_dedup_key(&entry);
+        entries.retain(|e| entry_dedup_key(e) != key);
         entries.insert(0, entry);
         if entries.len() > MAX_ENTRIES {
             entries.truncate(MAX_ENTRIES);
@@ -673,6 +707,18 @@ fn default_auto_continue() -> Value {
     })
 }
 
+// Dedup key for the notification list — one entry per workspace.
+// Prefer the workspace id: sibling workspaces can share a cwd, so the
+// path alone would wrongly merge them. Falls back to the normalized cwd
+// for sessions registered without a workspace id (older renderer, or
+// non-workspace sessions).
+fn entry_dedup_key(entry: &NotificationEntry) -> String {
+    match entry.workspace_id.as_deref() {
+        Some(id) if !id.is_empty() => format!("ws:{id}"),
+        _ => format!("cwd:{}", normalize_workspace_key(&entry.cwd)),
+    }
+}
+
 pub fn normalize_workspace_key(cwd: &str) -> String {
     let normalized = cwd
         .trim()
@@ -698,6 +744,7 @@ mod tests {
             session_id: "s1".into(),
             window_id: Some("main".into()),
             profile_id: None,
+            workspace_id: None,
             workspace_name: "ws".into(),
             cwd: cwd.into(),
             reason: "completed".into(),
@@ -736,6 +783,8 @@ mod tests {
         let mut session = AgentNotificationSession {
             window_id: Some("main".into()),
             profile_id: Some("default".into()),
+            workspace_id: None,
+            workspace_name: None,
             cwd: "/repo".into(),
             agent_kind: Some("claude".into()),
             model: None,
@@ -845,6 +894,14 @@ mod tests {
         assert!(!json.contains("\"result\":"));
         assert!(!json.contains("\"error\":"));
         assert!(!json.contains("\"agentKind\":"));
+        assert!(!json.contains("\"workspaceId\":"));
+    }
+
+    #[test]
+    fn entry_serializes_workspace_id_when_present() {
+        let e = workspace_entry("n1", "ws-1", "/repo");
+        let json = serde_json::to_string(&e).unwrap();
+        assert!(json.contains("\"workspaceId\":\"ws-1\""));
     }
 
     // We can't construct an AppHandle in unit tests, so the state
@@ -898,12 +955,18 @@ mod tests {
 
     fn raw_add(state: &NotificationState, entry: NotificationEntry) {
         let mut entries = state.lock();
-        let key = normalize_workspace_key(&entry.cwd);
-        entries.retain(|e| normalize_workspace_key(&e.cwd) != key);
+        let key = entry_dedup_key(&entry);
+        entries.retain(|e| entry_dedup_key(e) != key);
         entries.insert(0, entry);
         if entries.len() > MAX_ENTRIES {
             entries.truncate(MAX_ENTRIES);
         }
+    }
+
+    fn workspace_entry(id: &str, workspace_id: &str, cwd: &str) -> NotificationEntry {
+        let mut entry = sample_entry(id, cwd, false);
+        entry.workspace_id = Some(workspace_id.into());
+        entry
     }
 
     #[test]
@@ -974,6 +1037,32 @@ mod tests {
         let entries = state.lock();
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].id, "b");
+    }
+
+    #[test]
+    fn entry_dedup_key_prefers_workspace_id() {
+        let with_id = workspace_entry("a", "ws-1", "C:/repo");
+        assert_eq!(entry_dedup_key(&with_id), "ws:ws-1");
+        // No workspace id — fall back to the normalized cwd path.
+        let without_id = sample_entry("b", "C:/repo", false);
+        assert_eq!(entry_dedup_key(&without_id), "cwd:c:/repo");
+    }
+
+    #[test]
+    fn add_keeps_sibling_workspaces_sharing_a_cwd() {
+        let state = NotificationState::default();
+        // Two workspaces opened on the same repo folder.
+        raw_add(&state, workspace_entry("a", "ws-1", "C:/repo"));
+        raw_add(&state, workspace_entry("b", "ws-2", "C:/repo"));
+        // Same cwd, distinct workspace ids — both must survive.
+        assert_eq!(state.lock().len(), 2);
+        // A newer completion for ws-1 replaces only ws-1's entry.
+        raw_add(&state, workspace_entry("c", "ws-1", "C:/repo"));
+        let entries = state.lock();
+        assert_eq!(entries.len(), 2);
+        assert!(entries.iter().any(|e| e.id == "b"));
+        assert!(entries.iter().any(|e| e.id == "c"));
+        assert!(!entries.iter().any(|e| e.id == "a"));
     }
 
     #[test]

--- a/src-tauri/src/remote_core.rs
+++ b/src-tauri/src/remote_core.rs
@@ -191,6 +191,8 @@ pub fn legacy_v1_args_to_params(channel: &str, args: &[Value]) -> Value {
                 "codexApprovalPolicy": args.get(10).cloned().unwrap_or(Value::Null),
                 "permissionMode": args.get(11).cloned().unwrap_or(Value::Null),
                 "effort": args.get(12).cloned().unwrap_or(Value::Null),
+                "workspaceId": args.get(13).cloned().unwrap_or(Value::Null),
+                "workspaceName": args.get(14).cloned().unwrap_or(Value::Null),
             })),
         }),
         _ => legacy_v1_param_keys(channel)
@@ -457,6 +459,39 @@ mod tests {
                 "clientMessageId": "user-1",
                 "displayPrompt": "hi",
                 "suppressUserEcho": true,
+            })
+        );
+        // resume-session carries workspace identity in trailing positional
+        // args (13/14); they must land in the rebuilt options object.
+        assert_eq!(
+            legacy_v1_args_to_params(
+                "claude:resume-session",
+                &[
+                    json!("s1"),
+                    json!("sdk1"),
+                    json!("/repo"),
+                    Value::Null, // model
+                    Value::Null, // apiVersion
+                    Value::Null, // useWorktree
+                    Value::Null, // worktreePath
+                    Value::Null, // worktreeBranch
+                    Value::Null, // agentPreset
+                    Value::Null, // codexSandboxMode
+                    Value::Null, // codexApprovalPolicy
+                    Value::Null, // permissionMode
+                    Value::Null, // effort
+                    json!("ws-7"),
+                    json!("Plan 5.3.7"),
+                ]
+            ),
+            json!({
+                "sessionId": "s1",
+                "sdkSessionId": "sdk1",
+                "options": {
+                    "cwd": "/repo",
+                    "workspaceId": "ws-7",
+                    "workspaceName": "Plan 5.3.7",
+                },
             })
         );
     }

--- a/tests/host-api.test.ts
+++ b/tests/host-api.test.ts
@@ -997,6 +997,37 @@ async function run() {
     assert.equal(win?.batAppAPI?.foo, 1)
   }
 
+  // 9) startSession/resumeSession stamp workspace identity onto the
+  //    options when the session's terminal maps to a workspace. The
+  //    no-mapping case is covered by scenario 2 (payloads unchanged).
+  {
+    const invokeCalls: { cmd: string; args?: Record<string, unknown> }[] = []
+    const invoke: TauriInvoke = async <T>(cmd: string, args?: Record<string, unknown>) => {
+      invokeCalls.push({ cmd, args })
+      return { ok: true } as unknown as T
+    }
+    setWindow({ __TAURI_INTERNALS__: { invoke } })
+    const mod = await loadFreshAdapter()
+    const { workspaceStore } = await import('../renderer/src/stores/workspace-store')
+    const ws = workspaceStore.addWorkspace('Plan workspace', 'C:/repo')
+    const term = workspaceStore.addTerminal(ws.id, 'claude-code')
+    // alias takes priority over name in the stamped workspaceName.
+    workspaceStore.renameWorkspace(ws.id, 'Renamed workspace')
+
+    await mod.host.claude.startSession(term.id, { cwd: 'C:/repo' })
+    await mod.host.claude.resumeSession(term.id, 'sdk-1', 'C:/repo')
+
+    const startOptions = invokeCalls.find(c => c.cmd === 'claude_start_session')
+      ?.args?.options as { workspaceId?: string; workspaceName?: string } | undefined
+    assert.equal(startOptions?.workspaceId, ws.id)
+    assert.equal(startOptions?.workspaceName, 'Renamed workspace')
+
+    const resumeOptions = invokeCalls.find(c => c.cmd === 'claude_resume_session')
+      ?.args?.options as { workspaceId?: string; workspaceName?: string } | undefined
+    assert.equal(resumeOptions?.workspaceId, ws.id)
+    assert.equal(resumeOptions?.workspaceName, 'Renamed workspace')
+  }
+
   console.log('host-api: passed')
 }
 


### PR DESCRIPTION
## Problem

The notification center identifies entries by working directory. That falls apart when several workspaces are opened on the same repo folder (one workspace per task/branch in one repo is a common setup):

- **Label collision** — `workspaceName` is the cwd's last path segment (`workspace_name(cwd)`), so every workspace on the same folder shows an identical name.
- **Dedup collapse** — `add_entry` dedupes by normalized cwd, so a completion in one workspace replaces a sibling workspace's entry. With N workspaces in one repo, the center only ever holds one notification.
- **Focus is window-only** — clicking an entry (or Ctrl+Tab) raises the OS window via `focus_notification_window`, but workspaces are tabs inside a window, so the user lands on whatever tab was already active.

Net effect: with multiple workspaces in one repo, notifications are indistinguishable and clicking one doesn't take you to the workspace that finished.

## Fix

Carry **workspace identity** (id + display name) through the agent session end to end:

- `host-api.ts` — `startSession` / `resumeSession` stamp `workspaceId` + `workspaceName` (workspace alias or name) onto the options, resolved from the terminal→workspace mapping. Best-effort: sessions with no resolvable workspace are left untouched.
- `notification.rs` — `register_agent_session_from_options` records them on the session; `NotificationEntry` gains a `workspaceId` field and uses the real workspace name instead of the cwd basename.
- **Dedup** keys on `workspaceId` (falling back to cwd when absent), so sibling workspaces no longer collapse into one entry.
- **Focus** — after raising the window, `notification_focus_entry` / `notification_focus_latest_unread` emit a targeted `notification:activate-workspace` event to that window; the renderer switches to the workspace tab the agent actually ran in.

Backward compatible: sessions without a resolvable workspace (e.g. non-workspace sessions) keep the previous cwd-based behavior.

## Testing

- `cargo check --all-targets` — passes (verified on a Windows runner via GitHub Actions).
- New Rust unit tests: `entry_dedup_key_prefers_workspace_id`, `add_keeps_sibling_workspaces_sharing_a_cwd`, `entry_serializes_workspace_id_when_present`.
- `tsc --noEmit` — passes.
- `test:host-api`, `test:host-claude-coverage`, `test:host-direct-calls` — pass.
