### PR TITLE
fix(install): regex failed to exclude arm64.lightweight AppImage for linux x64 platform.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -95,7 +95,7 @@ elif [ "$OS" = "Linux" ]; then
         DOWNLOAD_URL=$(printf '%s\n' "$APPIMAGE_URLS" | grep -E '[-_]arm64\.AppImage$' | head -n 1)
     else
         # x64 has no arch marker in its name; exclude any arm64/aarch64 assets.
-        DOWNLOAD_URL=$(printf '%s\n' "$APPIMAGE_URLS" | grep -vE '[-_](arm64|aarch64)\.AppImage$' | head -n 1)
+        DOWNLOAD_URL=$(printf '%s\n' "$APPIMAGE_URLS" | grep -vE '[-_](arm64|aarch64)(\.lightweight)?\.AppImage$' | head -n 1)
     fi
     if [ -z "$DOWNLOAD_URL" ]; then
         echo "Error: Could not find a Linux $LINUX_ARCH .AppImage in the latest release." >&2


### PR DESCRIPTION
add an optional .lightweight in regex exclusion to prevent x64 platforms from mistakenly downloading arm64 lightweight assets.