### PR TITLE
fix: Windows terminal text corruption when running CJK-heavy TUIs (Claude Code)

### DIFF
--- a/renderer/src/components/TerminalPanel.tsx
+++ b/renderer/src/components/TerminalPanel.tsx
@@ -1,4 +1,4 @@
-import { host, type TerminalViewportState } from '../host-api'
+import { host, parseWindowsBuildNumber, type TerminalViewportState } from '../host-api'
 import { useEffect, useRef, useState, memo, type CSSProperties } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Terminal, type ILink } from '@xterm/xterm'
@@ -55,9 +55,7 @@ interface ContextMenu {
 
 function getWindowsBuildNumber(): number | undefined {
   if (host.platform !== 'win32') return undefined
-  const version = host.systemVersion
-  const build = Number(version.split('.').pop())
-  return Number.isFinite(build) ? build : undefined
+  return parseWindowsBuildNumber(host.systemVersion)
 }
 
 function isClaudeCliPreset(agentPreset?: AgentPresetId): boolean {

--- a/renderer/src/host-api.ts
+++ b/renderer/src/host-api.ts
@@ -209,6 +209,33 @@ function refreshTauriPtyInputTraceMode(): void {
   }
 }
 
+// Cached OS version string (Windows: "MAJOR.MINOR.BUILD"), fetched once at
+// host creation. Consumers (e.g. TerminalPanel's xterm windowsPty option)
+// must treat the empty-string default as "unknown", not "old Windows" — see
+// parseWindowsBuildNumber.
+let tauriSystemVersion = ''
+function refreshTauriSystemVersion(): void {
+  try {
+    void getInvoke()<string>('app_get_system_version')
+      .then(value => { tauriSystemVersion = typeof value === 'string' ? value : '' })
+      .catch(() => {})
+  } catch {
+    // Best-effort instrumentation only.
+  }
+}
+
+// Windows build number parsed from a "MAJOR.MINOR.BUILD" version string.
+// Returns undefined (not 0) when the version is empty or unparsable, so
+// callers that gate on "build < N" heuristics do not mistake "unknown" for
+// "old Windows".
+export function parseWindowsBuildNumber(version: string): number | undefined {
+  if (!version) return undefined
+  const last = version.split('.').pop()
+  if (!last) return undefined
+  const build = Number(last)
+  return Number.isFinite(build) ? build : undefined
+}
+
 function readTauriDebugMode(): boolean {
   if (tauriProcessDebugMode === true) return true
   const env = (import.meta as unknown as { env?: Record<string, string | boolean | undefined> }).env
@@ -468,10 +495,11 @@ function createTauriHost(): BatAppAPI {
   // throw via a Proxy so missing coverage fails loudly.
   refreshTauriDebugMode()
   refreshTauriPtyInputTraceMode()
+  refreshTauriSystemVersion()
   const platform = detectPlatform()
   const ported: Record<string, unknown> = {
     platform,
-    systemVersion: '',
+    get systemVersion() { return tauriSystemVersion },
     settings: {
       load: () => getInvoke()<string | null>('settings_load'),
       save: (data: string) => getInvoke()<void>('settings_save', { data }),
@@ -1641,7 +1669,7 @@ export function installTauriShim(): void {
     get(_t, prop) {
       const key = String(prop)
       if (key === 'platform') return platform
-      if (key === 'systemVersion') return ''
+      if (key === 'systemVersion') return tauriSystemVersion
       if (PORTED_NAMESPACES.has(key)) return real[key]
       // Build a nested namespace proxy that returns permissive values.
       return new Proxy({}, {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -80,7 +80,7 @@ rustls = { version = "0.23.40", default-features = false, features = ["ring", "s
 rustls-pki-types = "1.14.1"
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Security_Cryptography", "Win32_Storage_FileSystem", "Win32_System_Memory"] }
+windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Security_Cryptography", "Win32_Storage_FileSystem", "Win32_System_Memory", "Win32_System_SystemInformation", "Wdk_System_SystemServices"] }
 
 [dev-dependencies]
 # portable-pty exposes anyhow::Result in its public mockable traits. Keep this

--- a/src-tauri/src/commands/app.rs
+++ b/src-tauri/src/commands/app.rs
@@ -689,7 +689,7 @@ pub fn app_get_system_version() -> String {
 /// `GetVersionExW` is deliberately avoided: it is subject to application
 /// manifest compatibility shims and can silently report a stale Windows
 /// version. `RtlGetVersion` is unaffected by that shim.
-#[cfg(target_os = "windows")]
+#[cfg(all(feature = "desktop", target_os = "windows"))]
 fn os_version_string() -> String {
     use windows_sys::Wdk::System::SystemServices::RtlGetVersion;
     use windows_sys::Win32::System::SystemInformation::OSVERSIONINFOW;
@@ -706,7 +706,7 @@ fn os_version_string() -> String {
     )
 }
 
-#[cfg(not(target_os = "windows"))]
+#[cfg(all(feature = "desktop", not(target_os = "windows")))]
 fn os_version_string() -> String {
     String::new()
 }
@@ -882,6 +882,7 @@ mod tests {
         assert!(line.contains(" [tauri] hello\n"));
     }
 
+    #[cfg(feature = "desktop")]
     #[test]
     fn system_version_string_is_well_formed_on_windows() {
         let version = os_version_string();

--- a/src-tauri/src/commands/app.rs
+++ b/src-tauri/src/commands/app.rs
@@ -675,6 +675,42 @@ pub fn app_set_dock_badge(app: AppHandle, count: i64) {
     }
 }
 
+/// Real OS version string (Windows: `"MAJOR.MINOR.BUILD"`, e.g.
+/// `"10.0.26220"`). The renderer uses the build number to decide whether
+/// xterm's Windows ConPTY line-wrapping heuristics should apply — they only
+/// matter below build 21376, and a caller that cannot resolve a build number
+/// must treat that as "unknown", not "old ConPTY".
+#[cfg(feature = "desktop")]
+#[tauri::command]
+pub fn app_get_system_version() -> String {
+    os_version_string()
+}
+
+/// `GetVersionExW` is deliberately avoided: it is subject to application
+/// manifest compatibility shims and can silently report a stale Windows
+/// version. `RtlGetVersion` is unaffected by that shim.
+#[cfg(target_os = "windows")]
+fn os_version_string() -> String {
+    use windows_sys::Wdk::System::SystemServices::RtlGetVersion;
+    use windows_sys::Win32::System::SystemInformation::OSVERSIONINFOW;
+
+    let mut info: OSVERSIONINFOW = unsafe { std::mem::zeroed() };
+    info.dwOSVersionInfoSize = std::mem::size_of::<OSVERSIONINFOW>() as u32;
+    let status = unsafe { RtlGetVersion(&mut info) };
+    if status != 0 {
+        return String::new();
+    }
+    format!(
+        "{}.{}.{}",
+        info.dwMajorVersion, info.dwMinorVersion, info.dwBuildNumber
+    )
+}
+
+#[cfg(not(target_os = "windows"))]
+fn os_version_string() -> String {
+    String::new()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -844,5 +880,34 @@ mod tests {
     fn tauri_log_line_has_tauri_prefix() {
         let line = tauri_log_line("hello");
         assert!(line.contains(" [tauri] hello\n"));
+    }
+
+    #[test]
+    fn system_version_string_is_well_formed_on_windows() {
+        let version = os_version_string();
+        #[cfg(target_os = "windows")]
+        {
+            let parts: Vec<&str> = version.split('.').collect();
+            assert_eq!(
+                parts.len(),
+                3,
+                "expected MAJOR.MINOR.BUILD, got: {version:?}"
+            );
+            for part in &parts {
+                assert!(
+                    !part.is_empty() && part.chars().all(|c| c.is_ascii_digit()),
+                    "non-numeric segment in {version:?}"
+                );
+            }
+            // A manifest-shimmed API (GetVersionExW style) reports builds like
+            // 9200/9600; any real Windows 10+ machine is >= 10240 (Win10 RTM).
+            let build: u32 = parts[2].parse().expect("numeric build segment");
+            assert!(build >= 10240, "expected Windows build >= 10240, got {build}");
+        }
+        #[cfg(not(target_os = "windows"))]
+        {
+            // Non-Windows: an empty placeholder is an acceptable "unknown".
+            let _ = version;
+        }
     }
 }

--- a/src-tauri/src/commands/pty.rs
+++ b/src-tauri/src/commands/pty.rs
@@ -1220,6 +1220,75 @@ fn take_active_pty_session_for_generation(
     }
 }
 
+/// Accumulates PTY reader bytes across `read()` calls so a UTF-8 codepoint
+/// split across a chunk boundary decodes correctly instead of turning into
+/// U+FFFD. Bytes that are genuinely invalid UTF-8 (not just an incomplete
+/// trailing sequence) are still replaced with U+FFFD immediately, matching
+/// `String::from_utf8_lossy`'s behavior, so `pending` never grows past the
+/// handful of bytes a valid UTF-8 sequence can leave incomplete.
+struct Utf8ChunkDecoder {
+    pending: Vec<u8>,
+}
+
+impl Utf8ChunkDecoder {
+    fn new() -> Self {
+        Self {
+            pending: Vec::new(),
+        }
+    }
+
+    /// Decode a newly read chunk, prefixed with any bytes held back from the
+    /// previous call. Bytes that look like the start of a still-incomplete
+    /// UTF-8 sequence at the end of the combined buffer are kept in
+    /// `self.pending` for the next call instead of being lossy-replaced.
+    fn decode(&mut self, bytes: &[u8]) -> String {
+        let mut buf = std::mem::take(&mut self.pending);
+        buf.extend_from_slice(bytes);
+        let mut out = String::with_capacity(buf.len());
+        let mut remaining: &[u8] = &buf;
+        loop {
+            match std::str::from_utf8(remaining) {
+                Ok(valid) => {
+                    out.push_str(valid);
+                    break;
+                }
+                Err(err) => {
+                    let valid_up_to = err.valid_up_to();
+                    out.push_str(
+                        std::str::from_utf8(&remaining[..valid_up_to])
+                            .expect("valid_up_to always points at a valid UTF-8 boundary"),
+                    );
+                    match err.error_len() {
+                        Some(bad_len) => {
+                            // Genuinely invalid bytes: replace immediately so
+                            // pending never accumulates them.
+                            out.push('\u{FFFD}');
+                            remaining = &remaining[valid_up_to + bad_len..];
+                        }
+                        None => {
+                            // Trailing bytes look like the start of a valid
+                            // sequence that the next read will complete.
+                            self.pending = remaining[valid_up_to..].to_vec();
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+        out
+    }
+
+    /// Flush any bytes still held back once the reader hits EOF or an error,
+    /// so a truncated trailing sequence is surfaced (lossily) instead of
+    /// silently dropped.
+    fn flush(&mut self) -> Option<String> {
+        if self.pending.is_empty() {
+            return None;
+        }
+        Some(String::from_utf8_lossy(&std::mem::take(&mut self.pending)).into_owned())
+    }
+}
+
 pub(crate) fn start_pty_session(
     app: &HostContext,
     map_handle: Arc<Mutex<HashMap<String, PtyEntry>>>,
@@ -1281,8 +1350,9 @@ pub(crate) fn start_pty_session(
     })?;
 
     // Reader thread: pump bytes from PTY → coalesced pty:output events.
-    // Lossy UTF-8 because xterm.js consumes strings and PTYs can split
-    // codepoints across reads; renderer can stitch via terminal state.
+    // PTYs can split a UTF-8 codepoint across reads, so decode through
+    // Utf8ChunkDecoder to stitch valid split sequences back together;
+    // only genuinely invalid bytes become U+FFFD.
     let id_for_reader = options.id.clone();
     let app_for_reader = app.clone();
     let (output_tx, output_done) = spawn_output_coalescer(
@@ -1340,9 +1410,15 @@ pub(crate) fn start_pty_session(
     std::thread::spawn(move || {
         let _done = reader_thread_done;
         let mut buf = [0u8; 4096];
+        let mut decoder = Utf8ChunkDecoder::new();
         loop {
             match reader.read(&mut buf) {
-                Ok(0) => break,
+                Ok(0) => {
+                    if let Some(tail) = decoder.flush() {
+                        let _ = output_tx.send(tail);
+                    }
+                    break;
+                }
                 Ok(n) => {
                     if pty_output_debug_enabled() && pty_output_bytes_trace_required(&buf[..n]) {
                         pty_output_debug_log(
@@ -1353,12 +1429,17 @@ pub(crate) fn start_pty_session(
                             ),
                         );
                     }
-                    let chunk = String::from_utf8_lossy(&buf[..n]).into_owned();
-                    if output_tx.send(chunk).is_err() {
+                    let chunk = decoder.decode(&buf[..n]);
+                    if !chunk.is_empty() && output_tx.send(chunk).is_err() {
                         break;
                     }
                 }
-                Err(_) => break,
+                Err(_) => {
+                    if let Some(tail) = decoder.flush() {
+                        let _ = output_tx.send(tail);
+                    }
+                    break;
+                }
             }
         }
         drop(output_tx);
@@ -2513,5 +2594,68 @@ mod tests {
             cmd.get_env("COLORTERM").and_then(|value| value.to_str()),
             Some("false")
         );
+    }
+
+    #[test]
+    fn utf8_chunk_decoder_stitches_three_byte_codepoint_split_1_2() {
+        // "中" = E4 B8 AD, split after the first byte.
+        let mut decoder = Utf8ChunkDecoder::new();
+        let mut out = String::new();
+        out.push_str(&decoder.decode(b"\xE4"));
+        out.push_str(&decoder.decode(b"\xB8\xAD"));
+        assert_eq!(out, "中");
+        assert!(!out.contains('\u{FFFD}'), "unexpected replacement char in {out:?}");
+    }
+
+    #[test]
+    fn utf8_chunk_decoder_stitches_three_byte_codepoint_split_2_1() {
+        // "中" = E4 B8 AD, split after the second byte.
+        let mut decoder = Utf8ChunkDecoder::new();
+        let mut out = String::new();
+        out.push_str(&decoder.decode(b"\xE4\xB8"));
+        out.push_str(&decoder.decode(b"\xAD"));
+        assert_eq!(out, "中");
+        assert!(!out.contains('\u{FFFD}'), "unexpected replacement char in {out:?}");
+    }
+
+    #[test]
+    fn utf8_chunk_decoder_stitches_four_byte_emoji_split_2_2() {
+        // "😀" = F0 9F 98 80, split down the middle.
+        let mut decoder = Utf8ChunkDecoder::new();
+        let mut out = String::new();
+        out.push_str(&decoder.decode(b"\xF0\x9F"));
+        out.push_str(&decoder.decode(b"\x98\x80"));
+        assert_eq!(out, "😀");
+        assert!(!out.contains('\u{FFFD}'), "unexpected replacement char in {out:?}");
+    }
+
+    #[test]
+    fn utf8_chunk_decoder_stitches_mixed_ascii_and_split_codepoint() {
+        let mut decoder = Utf8ChunkDecoder::new();
+        let mut out = String::new();
+        out.push_str(&decoder.decode(b"abc\xE4"));
+        out.push_str(&decoder.decode(b"\xB8\xAD def"));
+        assert_eq!(out, "abc中 def");
+        assert!(!out.contains('\u{FFFD}'), "unexpected replacement char in {out:?}");
+    }
+
+    #[test]
+    fn utf8_chunk_decoder_replaces_genuinely_invalid_byte() {
+        // 0xFF is never a valid UTF-8 lead byte; it must still lossy-decode
+        // to U+FFFD instead of being held in `pending` forever.
+        let mut decoder = Utf8ChunkDecoder::new();
+        let out = decoder.decode(b"ab\xFFcd");
+        assert_eq!(out, "ab\u{FFFD}cd");
+        assert!(decoder.flush().is_none(), "invalid bytes must not linger in pending");
+    }
+
+    #[test]
+    fn utf8_chunk_decoder_flushes_pending_tail_on_eof() {
+        let mut decoder = Utf8ChunkDecoder::new();
+        let out = decoder.decode(b"abc\xE4");
+        assert_eq!(out, "abc");
+        let flushed = decoder.flush().expect("incomplete tail must be flushed");
+        assert_eq!(flushed, "\u{FFFD}");
+        assert!(decoder.flush().is_none(), "pending must be empty after flush");
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -302,6 +302,7 @@ fn app_builder(headless: bool) -> tauri::Builder<tauri::Wry> {
             app_cmd::app_get_window_index,
             app_cmd::app_get_launch_profile,
             app_cmd::app_get_window_profile,
+            app_cmd::app_get_system_version,
             app_cmd::app_set_title,
             app_cmd::app_resolve_profile_window_close,
             app_cmd::app_new_window,

--- a/tests/host-api.test.ts
+++ b/tests/host-api.test.ts
@@ -29,6 +29,7 @@ function stripBestEffortDebugModeCall<T extends { cmd: string }>(calls: T[]): T[
   return calls.filter(call => ![
     'debug_is_debug_mode',
     'debug_is_pty_input_trace',
+    'app_get_system_version',
   ].includes(call.cmd))
 }
 
@@ -51,6 +52,7 @@ async function run() {
       // Mirror Rust return shapes for the commands we care about.
       if (cmd === 'debug_is_debug_mode') return false as unknown as T
       if (cmd === 'debug_is_pty_input_trace') return false as unknown as T
+      if (cmd === 'app_get_system_version') return '10.0.26220' as unknown as T
       if (cmd === 'settings_load') return null as unknown as T
       if (cmd === 'settings_save') return undefined as unknown as T
       if (cmd === 'shell_open_external') return undefined as unknown as T
@@ -267,7 +269,11 @@ async function run() {
       ['win32', 'darwin', 'linux'].includes(mod.host.platform),
       `unexpected platform: ${mod.host.platform}`,
     )
-    assert.equal(mod.host.systemVersion, '')
+    // systemVersion resolves asynchronously (app_get_system_version) and is
+    // cached in the module; give the pending invoke a tick to settle before
+    // asserting the final value.
+    await new Promise(resolve => setTimeout(resolve, 0))
+    assert.equal(mod.host.systemVersion, '10.0.26220')
 
     const loaded = await mod.host.settings.load()
     assert.equal(loaded, null)
@@ -1101,6 +1107,17 @@ async function run() {
       ?.args?.options as { workspaceId?: string; workspaceName?: string } | undefined
     assert.equal(resumeOptions?.workspaceId, ws.id)
     assert.equal(resumeOptions?.workspaceName, 'Renamed workspace')
+  }
+
+  // 10) parseWindowsBuildNumber must never coerce an empty/unparsable
+  //     version into 0 (Number('') === 0 is exactly the bug this guards
+  //     against — it would otherwise wrongly enable xterm's old-ConPTY
+  //     line-wrapping heuristics on every unresolved systemVersion).
+  {
+    const mod = await loadFreshAdapter()
+    assert.equal(mod.parseWindowsBuildNumber(''), undefined)
+    assert.equal(mod.parseWindowsBuildNumber('10.0.26220'), 26220)
+    assert.equal(mod.parseWindowsBuildNumber('abc'), undefined)
   }
 
   console.log('host-api: passed')


### PR DESCRIPTION
## 問題

Windows 上用內建終端跑 Claude Code 時，文字容易跑版（行內容右移、box 邊框錯位、出現 � 亂碼），拉動視窗大小會暫時恢復，但輸出一多又會歪掉。直接在 PowerShell / Windows Terminal 跑同樣的 Claude Code 則正常。

## 根因一（主因）：PTY reader 逐 chunk lossy UTF-8 轉換

`src-tauri/src/commands/pty.rs` 的 reader thread 對每個 `read()` chunk 各自做 `String::from_utf8_lossy`。CJK（3 bytes）/ emoji（4 bytes）被讀取邊界切開時，會被替換成 U+FFFD——部分切法（例如 3-byte 字切成 1+2）會讓原本 2 欄寬的字變成 3 個 1 欄字元，該行後續內容整體右移一欄。

實測證據（真實 ConPTY、大量 CJK 輸出）：

- 286,433 bytes / 122 chunks，其中 74 個 chunk 不是自含合法 UTF-8
- 逐 chunk lossy 轉換 → 74 個 U+FFFD
- 整條 byte 流一次轉換 → 0 個 U+FFFD（證明 ConPTY 輸出本身合法，損毀完全來自逐 chunk 轉換）

這也解釋了症狀特徵：輸出越多越歪（損毀累積）、拉視窗暫時恢復（ConPTY 全螢幕重繪蓋掉壞格）。

**修法**：新增 `Utf8ChunkDecoder`——不完整的多位元組尾端（≤3 bytes）保留到下一次 read 一併解碼；真正非法的 bytes 仍立即以 U+FFFD 呈現；EOF / read error 時 flush 殘留。附 6 個單元測試（修正前失敗、修正後通過）。

## 根因二（次因）：xterm 拿到 buildNumber = 0

Tauri host 的 `host.systemVersion` 一直是硬編碼空字串，`TerminalPanel` 算出 `Number('') === 0`，xterm 收到 `windowsPty: { backend: 'conpty', buildNumber: 0 }`。xterm 5.5 的判斷是 `heuristics = backend === 'conpty' && buildNumber < 21376`，所以所有 Windows 使用者都被錯誤套用針對 2021 年前舊 ConPTY 的 wrapping heuristics，影響 resize 前後的換行/reflow 正確性。

**修法**：

- Rust 新增 `app_get_system_version`（用 `RtlGetVersion`，避開會被 manifest 相容性 shim 影響的 `GetVersionExW`），回傳如 `"10.0.26220"`
- renderer 啟動時非同步快取；新增 `parseWindowsBuildNumber`：空字串／不可解析回 `undefined` 而非 0（unknown 不等於 old Windows）
- Win10（build < 21376）使用者依然會正確啟用 heuristics

## 驗證

- `cargo test --lib`：新增 7 個測試全過，無新增失敗
- `pnpm exec tsc --noEmit`、`pnpm run test:host-api`、`pnpm run compile` 全過
- 實機驗證：Windows 11 build 26220，修正版跑 Claude Code 長時間 CJK 輸出，跑版現象消失

## 已知限制

- `systemVersion` 為非同步取得，理論上 app 啟動瞬間掛載的終端可能拿到 `undefined`（→ heuristics off）。在 build ≥ 21376 的系統上這與拿到真值的行為相同；只有 Win10 且終端在第一瞬間掛載的罕見組合會退回 xterm 預設行為。
