### PR TITLE
feat(terminal): render with WebGL so CJK font fallback cannot shift columns

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,6 +117,7 @@
     "@modelcontextprotocol/sdk": "^1.30.0",
     "@openai/codex": "0.153.2",
     "@vscode/ripgrep": "^1.17.1",
+    "@xterm/addon-webgl": "^0.18.0",
     "better-sqlite3": "^12.5.0",
     "papaparse": "^5.7.0",
     "selfsigned": "^5.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@vscode/ripgrep':
         specifier: ^1.17.1
         version: 1.17.1
+      '@xterm/addon-webgl':
+        specifier: ^0.18.0
+        version: 0.18.0(@xterm/xterm@5.5.0)
       better-sqlite3:
         specifier: ^12.5.0
         version: 12.9.0
@@ -1307,6 +1310,11 @@ packages:
 
   '@xterm/addon-web-links@0.11.0':
     resolution: {integrity: sha512-nIHQ38pQI+a5kXnRaTgwqSHnX7KE6+4SVoceompgHL26unAxdfP6IPqUTSYPQgSwM56hsElfoNrrW5V7BUED/Q==}
+    peerDependencies:
+      '@xterm/xterm': ^5.0.0
+
+  '@xterm/addon-webgl@0.18.0':
+    resolution: {integrity: sha512-xCnfMBTI+/HKPdRnSOHaJDRqEpq2Ugy8LEj9GiY4J3zJObo3joylIFaMvzBwbYRg8zLtkO0KQaStCeSfoaI2/w==}
     peerDependencies:
       '@xterm/xterm': ^5.0.0
 
@@ -3565,6 +3573,10 @@ snapshots:
       '@xterm/xterm': 5.5.0
 
   '@xterm/addon-web-links@0.11.0(@xterm/xterm@5.5.0)':
+    dependencies:
+      '@xterm/xterm': 5.5.0
+
+  '@xterm/addon-webgl@0.18.0(@xterm/xterm@5.5.0)':
     dependencies:
       '@xterm/xterm': 5.5.0
 

--- a/renderer/src/components/TerminalPanel.tsx
+++ b/renderer/src/components/TerminalPanel.tsx
@@ -5,6 +5,7 @@ import { Terminal, type ILink } from '@xterm/xterm'
 import { FitAddon } from '@xterm/addon-fit'
 import { WebLinksAddon } from '@xterm/addon-web-links'
 import { Unicode11Addon } from '@xterm/addon-unicode11'
+import { WebglAddon } from '@xterm/addon-webgl'
 import { workspaceStore } from '../stores/workspace-store'
 import { settingsStore } from '../stores/settings-store'
 import type { AgentPresetId } from '../types/agent-presets'
@@ -589,6 +590,27 @@ export const TerminalPanel = memo(function TerminalPanel({
     window.addEventListener('keydown', handleNativeTerminalKeydown, true)
 
     terminal.open(containerRef.current)
+
+    // The DOM renderer lays a row out with the browser's text flow, so a run
+    // that falls back to a second CJK font (Japanese 弾/顔 next to Traditional
+    // Chinese on Windows, for example) no longer measures a whole number of
+    // cells and every column after it drifts — table borders end up one cell
+    // off on exactly those rows. The WebGL renderer draws each glyph into its
+    // own cell. Keep the DOM renderer when WebGL is unavailable or lost.
+    let webglAddon: WebglAddon | null = null
+    try {
+      webglAddon = new WebglAddon()
+      webglAddon.onContextLoss(() => {
+        dlog(`[render] webgl context lost, using DOM renderer terminal=${terminalId}`)
+        webglAddon?.dispose()
+        webglAddon = null
+      })
+      terminal.loadAddon(webglAddon)
+    } catch (error) {
+      dlog(`[render] webgl renderer unavailable, using DOM renderer terminal=${terminalId}`, error)
+      webglAddon?.dispose()
+      webglAddon = null
+    }
 
     // Register file:// URL link provider (WebLinksAddon only handles http/https)
     terminal.registerLinkProvider({


### PR DESCRIPTION
## Problem

On Windows, markdown tables rendered by Claude Code come out with some rows shifted by about a cell: the column borders on rows such as `弾着・装填` and `公務の顔・座って食べ・報告口調` no longer line up with the rows around them, while rows with the same `・` and similar CJK content stay aligned.

The terminal runs xterm.js's DOM renderer (no webgl/canvas addon). That renderer lays each row out with the browser's text flow, so cell alignment relies on every glyph run measuring a whole number of cells. With the default Windows font stack (`Consolas, "Courier New", monospace`) Traditional Chinese falls back to Microsoft JhengHei, but Japanese-only forms like 弾 or 顔 fall back again to Yu Gothic, and that run's advance no longer equals `2 × cell`. Everything after it on the row drifts.

Width tables are not the cause: conhost, xterm's Unicode 11 provider and Unicode 15 East Asian Width agree on all 69 characters checked (CJK, fullwidth punctuation, box drawing, arrows, emoji). A standalone xterm.js page (no ConPTY involved, same xterm build, Consolas 16px on Windows 11) reproduces the exact same rows drifting under the DOM renderer, and the same buffer under the WebGL renderer is perfectly aligned.

## Fix

Load `@xterm/addon-webgl` (0.18.x, the line that pairs with xterm 5.5) after `terminal.open()`. The WebGL renderer draws each glyph into its own cell, so font fallback cannot move the columns. If WebGL is unavailable, or the context is lost later, the addon is disposed and xterm falls back to the DOM renderer, so nothing regresses on machines without GPU acceleration.

Nothing else in `TerminalPanel` depends on the DOM renderer: the `MutationObserver` watches the helper textarea's style, which exists with either renderer.

## Verification

- `pnpm exec tsc --noEmit`, `pnpm run compile` (the addon lands in the `xterm` chunk).
- Standalone reproduction page with the same table, font and xterm build: DOM renderer drifts on the two rows above, WebGL renderer aligns them.
- Lockfile updated with the pinned package manager (`corepack pnpm add`), 12 lines.
